### PR TITLE
Multidimensional display isn't working properly

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -69,12 +69,6 @@ include("quadratic.jl")
 # This creates getindex methods for all supported combinations
 for IT in (Constant{OnCell},Linear{OnGrid},Quadratic{ExtendInner,OnCell},Quadratic{Flat,OnCell})
     for EB in (ExtrapError,ExtrapNaN,ExtrapConstant)
-
-        eval(:(function getindex{T}(itp::Interpolation{T,1,$IT,$EB}, x::Real, d)
-            d == 1 || throw(BoundsError())
-            itp[x]
-        end))
-
         it = IT()
         eb = EB()
         gr = gridrepresentation(it)


### PR DESCRIPTION
Check out this PR and run from the package directory:

```
$ julia  test/output.jl 
3-element Interpolation{Float64,1,Linear{OnGrid},ExtrapError}:
 0.0952039
 0.438459 
 0.758061 
3-element Interpolation{Float64,1,Linear{OnGrid},ExtrapError}:
 0.0952039
 5.0      
 0.758061 
3x3 Interpolation{Float64,2,Linear{OnGrid},ExtrapError}:
 0.355406  0.875922  0.569037
 0.512562  0.506918  0.78563 
 0.327117  0.509231  0.931878
3x3x3 Interpolation{Float64,3,Linear{OnGrid},ExtrapError}:
[:, :, 1] =
 #undef  #undef  #undef
 #undef  #undef  #undef
 #undef  #undef  #undef

[:, :, 2] =
 #undef  #undef  #undef
 #undef  #undef  #undef
 #undef  #undef  #undef

[:, :, 3] =
 #undef  #undef  #undef
 #undef  #undef  #undef
 #undef  #undef  #undef
```

For 1D and 2D we fixed it by adding a method `getindex{T}(itp::Interpolation{T,1}, x::Real, d)` which only worked for `d==1`, but apparently it doesn't help in 3D. Adding similar methods with an extra argument for 2D and 3D as per definitions below doesn't seem to mitigate the issue

```
getindex{T}(itp::Interpolation{T,2}, x::Real, y::Real, d) = (d==1 || throw(BoundsError()); itp[x,y])
getindex{T}(itp::Interpolation{T,3}, x::Real, y::Real, z::Real, d) = (d==1 || throw(BoundsError()); itp[x,y,z])
```

 Is there anything that can be done about this?
