### PR TITLE
Gradient evaluation

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -161,11 +161,10 @@ for IT in (
         eval(ngenerate(
             :N,
             :(Array{promote_type(T,typeof(x)...),1}),
-            :(gradient{T,N}(itp::Interpolation{T,N,$IT,$EB}, x::NTuple{N,Real}...)),
+            :(gradient!{T,N}(g::Array{T,1}, itp::Interpolation{T,N,$IT,$EB}, x::NTuple{N,Real}...)),
             N->quote
                 $(extrap_transform_x(gr,eb,N))
                 $(define_indices(it,N))
-                ret = Array(T,$N)
                 @nexprs $N dim->begin
                     @nexprs $N d->begin
                         (d==dim
@@ -173,13 +172,15 @@ for IT in (
                             : $(coefficients(it,N,:d)))
                     end
 
-                    @inbounds ret[dim] = $(index_gen(degree(it),N))
+                    @inbounds g[dim] = $(index_gen(degree(it),N))
                 end
-                ret
+                g
             end
         ))
     end
 end
+
+gradient{T}(itp::Interpolation{T}, x...) = gradient!(Array(T,ndims(itp)), itp, x...)
 
 # This creates prefilter specializations for all interpolation types that need them
 for IT in (

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -169,11 +169,11 @@ for IT in (
                 @nexprs $N dim->begin
                     @nexprs $N d->begin
                         (d==dim
-                            ? $(gradient_coefficients(it,N,:dim))
-                            : $(coefficients(it,N,:dim)))
-
-                        @inbounds ret[dim] = $(index_gen(degree(it),N))
+                            ? $(gradient_coefficients(it,N,:d))
+                            : $(coefficients(it,N,:d)))
                     end
+
+                    @inbounds ret[dim] = $(index_gen(degree(it),N))
                 end
                 ret
             end

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -6,8 +6,18 @@ function define_indices(::Constant, N)
     :(@nexprs $N d->(ix_d = clamp(round(Int,x_d), 1, size(itp,d))))
 end
 
-function coefficients(::Constant, N)
-    :(@nexprs $N d->(c_d = one(typeof(x_d))))
+function coefficients(c::Constant, N)
+    :(@nexprs $N d->($(coefficients(c, N, :d))))
+end
+
+function coefficients(::Constant, N, d)
+    sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
+    :($sym = one(typeof($symx)))
+end
+
+function gradient_coefficients(::Constant, N, d)
+    sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
+    :($sym = zero(typeof($symx)))
 end
 
 function index_gen(degree::ConstantDegree, N::Integer, offsets...)

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -12,12 +12,23 @@ function define_indices(::Linear, N)
     end
 end
 
-function coefficients(::Linear, N)
+function coefficients(l::Linear, N)
+    :(@nexprs $N d->($(coefficients(l, N, :d))))
+end
+
+function coefficients(::Linear, N, d)
+    sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
     quote
-        @nexprs $N d->begin
-            c_d = one(typeof(fx_d)) - fx_d
-            cp_d = fx_d
-        end
+        $sym = one(typeof($symfx)) - $symfx
+        $symp = $symfx
+    end
+end
+
+function gradient_coefficients(::Linear,N,d)
+    sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
+    quote
+        $sym = -one(typeof($symfx))
+        $symp = one(typeof($symfx))
     end
 end
 

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -28,13 +28,27 @@ function define_indices(q::Quadratic{Periodic}, N)
     end
 end
 
-function coefficients(::Quadratic, N)
+function coefficients(q::Quadratic, N)
+    :(@nexprs $N d->($(coefficients(q, N, :d))))
+end
+
+function coefficients(q::Quadratic, N, d)
+    symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
+    symfx = symbol(string("fx_",d))
     quote
-        @nexprs $N d->begin
-            cm_d = .5 * (fx_d-.5)^2
-            c_d = .75 - fx_d^2
-            cp_d = .5 * (fx_d+.5)^2
-        end
+        $symm = .5 * ($symfx - .5)^2
+        $sym  = .75 - $symfx^2
+        $symp = .5 * ($symfx + .5)^2
+    end
+end
+
+function gradient_coefficients(q::Quadratic, N, d)
+    symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
+    symfx = symbol(string("fx_",d))
+    quote
+        $symm = $symfx-.5
+        $sym = -2*$symfx
+        $symp = $symfx+.5
     end
 end
 

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -1,0 +1,30 @@
+module GradientTests
+println("Testing gradient evaluation")
+using Base.Test, Interpolations
+
+nx = 10
+f1(x) = sin((x-3)*2pi/(nx-1) - 1)
+g1(x) = 2pi/(nx-1) * cos((x-3)*2pi/(nx-1) - 1)
+
+# Gradient of Constant should always be 0
+itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
+            Constant(OnGrid()), ExtrapPeriodic())
+for x in 1:nx
+    @test gradient(itp1, x)[1] == 0
+end
+
+# Since Linear is OnGrid in the domain, check the gradients between grid points
+itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
+            Linear(OnGrid()), ExtrapPeriodic())
+for x in 2.5:nx-1.5
+    @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.1*g1(x))
+end
+
+# Since Quadratic is OnCell in the domain, check gradients at grid points
+itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1], 
+            Quadratic(Periodic(),OnGrid()), ExtrapPeriodic())
+for x in 2:nx-1
+    @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.05*g1(x))
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,9 @@ include("quadratic.jl")
 # indices inbounds in A.
 include("on-grid.jl")
 
+# test gradient evaluation
+include("gradient.jl")
+
 # Tests copied from Grid.jl's old test suite
 #include("grid.jl")
 


### PR DESCRIPTION
I got it working! =)

The interface is currently a little clunky, especially in 1D, but I couldn't think of a way to define an overload of `gradient` for vector interpolations, that wouldn't be recursive. This is how it works:

```
using Interpolations
xg = 1:15
xf = 1:.1:15
f1(x) = sin(2pi/15 * (x-1))
g1(x)= 2pi/15 * cos(2pi/15*(x-1))

f1g = f1(xg)
g1g = g1(xg)

itp1 = Interpolation(f1g, Quadratic(Free(),OnCell()), ExtrapNaN())
f1i = Float64[itp1[x] for x in xf]
g1i = Float64[gradient(itp1, x)[1] for x in xf]

using Gadfly
plot(
	layer(x=xg,y=fg,Geom.point),
	layer(x=xg,y=gg,Geom.point,Theme(default_color=color("red"))),
	layer(x=xf,y=f1i,Geom.path),
	layer(x=xf,y=g1i,Geom.path,Theme(default_color=color("red"))),
)
```

![gradient](https://cloud.githubusercontent.com/assets/1550920/5587487/a0fb2ddc-90ec-11e4-85dc-27c47ba3b1c7.png)

It works for linear and constant interpolations too, although the results are of course less useful:

![gradient-constant](https://cloud.githubusercontent.com/assets/1550920/5587497/c7956a02-90ec-11e4-9773-87cd8213e0dd.png)
![gradient-linear](https://cloud.githubusercontent.com/assets/1550920/5587491/b15896ec-90ec-11e4-9a1c-c4de18d45825.png)

The meta-programming mumbo-jumbo used to define the correct coefficients for evaluation became more complicated, and as a result (other than the code being a little more opaque), the loading time of the package is bumped up even further; `tic(); using Interpolations; toc()` now reports 31 seconds on my machine. For comparison, `tic(); using Gadfly; toc()` reports 25... It might be possible to reduce the load time slightly by organizing the code into smaller modules where things like `symm`, `sym` and `symp` could be defined as constants, but I guess much of this would be alleviated with staged functions, so I'm not very concerned about it at the moment.