### PR TITLE
WIP: Output type handling (fixes #17)

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -123,12 +123,6 @@ function copy_with_padding(A, it::InterpolationType)
     coefs, pad
 end
 
-# This resolves ambiguity with general array indexing,
-#   getindex{T,N}(A::AbstractArray{T,N}, I::AbstractArray{T,N})
-eval(ngenerate(:N, :T, :(getindex{T,N}(itp::Interpolation{T,N}, I::AbstractArray{T,N})),
-    N->:(error("Array indexing is not defined for interpolation objects."))
-))
-
 # This creates getindex methods for all supported combinations
 for IT in (
         Constant{OnGrid},
@@ -187,6 +181,12 @@ for IT in (
         # Resolve ambiguity with real multilinear indexing
         #   getindex{T,N}(A::AbstractArray{T,N}, NTuple{N,Real}...)
         eval(ngenerate(:N, :T, :(getindex{T,N,TCoefs}(itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N,Real}...)), getindex_impl))
+
+        # Resolve ambiguity with general array indexing,
+        #   getindex{T,N}(A::AbstractArray{T,N}, I::AbstractArray{T,N})
+        eval(ngenerate(:N, :T, :(getindex{T,N}(itp::Interpolation{T,N}, I::AbstractArray{T,N})),
+            N->:(error("Array indexing is not defined for interpolation objects."))
+        ))
 
         # Allow multilinear indexing with any types
         eval(ngenerate(:N, :(promote_type(T,TIndex)), :(getindex{T,N,TCoefs,TIndex}(itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N,TIndex}...)), getindex_impl))

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -79,7 +79,7 @@ Interpolation{TIn,N,IT<:InterpolationType,EB<:ExtrapolationBehavior}(A::Abstract
 # We also ensure that the coefficient array is of the correct type
 prefilter{T,N,TCoefs,IT<:InterpolationType}(::Type{TCoefs}, A::AbstractArray{T,N}, ::IT) = copy!(Array(TCoefs,size(A)...), A)
 
-size{T,N,TCoefs,IT<:InterpolationType}(itp::Interpolation{T,N,TCoefs,IT}, d::Integer) = size(itp.coefs, d) - 2*padding(TCoefs,IT())
+size{T,N,TCoefs,IT<:InterpolationType}(itp::Interpolation{T,N,TCoefs,IT}, d::Integer) = size(itp.coefs, d) - 2*padding(Int,IT())
 size(itp::AbstractInterpolation) = tuple([size(itp,i) for i in 1:ndims(itp)]...)
 ndims(itp::Interpolation) = ndims(itp.coefs)
 eltype{T}(itp::Interpolation{T}) = T
@@ -115,7 +115,7 @@ function pad_size_and_index(sz::Tuple, pad)
     sz, ind
 end
 function copy_with_padding(TCoefs, A, it::InterpolationType)
-    pad = padding(it)
+    pad = padding(Int, it)
     sz,ind = pad_size_and_index(size(A), pad)
     coefs = fill!(Array(TCoefs, sz...), 0)
     coefs[ind...] = A

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -184,8 +184,14 @@ for IT in (
 
         # Resolve ambiguity with general array indexing,
         #   getindex{T,N}(A::AbstractArray{T,N}, I::AbstractArray{T,N})
-        eval(ngenerate(:N, :T, :(getindex{T,N}(itp::Interpolation{T,N}, I::AbstractArray{T,N})),
+        eval(ngenerate(:N, :T, :(getindex{T,N,TCoefs}(itp::Interpolation{T,N,TCoefs,$IT,$EB}, I::AbstractArray{T})),
             N->:(error("Array indexing is not defined for interpolation objects."))
+        ))
+
+        # Resolve ambiguity with colon indexing for 1D interpolations
+        #   getindex{T}(A::AbstractArray{T,1}, C::Colon)
+        eval(ngenerate(:N, :T, :(getindex{T,TCoefs}(itp::Interpolation{T,1,TCoefs,$IT,$EB}, c::Colon)),
+            N->:(error("Colon indexing is not supported for interpolation objects"))
         ))
 
         # Allow multilinear indexing with any types
@@ -193,7 +199,7 @@ for IT in (
 
         # Define in-place gradient calculation
         #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
-        eval(ngenerate(:N, :(Vector{TOut}), :(gradient!{T,N,TCoefs}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N}...)),
+        eval(ngenerate(:N, :(Vector{TOut}), :(gradient!{T,N,TCoefs,TOut}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N,Any}...)),
             N->quote
                 length(g) == N || error("g must be an array with exactly N elements (length(g) == "*string(length(g))*", N == "*string(N)*")")
                 $(extrap_transform_x(gr,eb,N))

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -36,16 +36,16 @@ export
 abstract Degree{N}
 
 abstract GridRepresentation
-type OnGrid <: GridRepresentation end
-type OnCell <: GridRepresentation end
+immutable OnGrid <: GridRepresentation end
+immutable OnCell <: GridRepresentation end
 
 abstract BoundaryCondition
-type None <: BoundaryCondition end
-type Flat <: BoundaryCondition end
-type Line <: BoundaryCondition end
+immutable None <: BoundaryCondition end
+immutable Flat <: BoundaryCondition end
+immutable Line <: BoundaryCondition end
 typealias Natural Line
-type Free <: BoundaryCondition end
-type Periodic <: BoundaryCondition end
+immutable Free <: BoundaryCondition end
+immutable Periodic <: BoundaryCondition end
 immutable Reflect <: BoundaryCondition end
 
 abstract InterpolationType{D<:Degree,BC<:BoundaryCondition,GR<:GridRepresentation}

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -201,7 +201,7 @@ for IT in (
         #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
         eval(ngenerate(:N, :(Vector{TOut}), :(gradient!{T,N,TCoefs,TOut}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N,Any}...)),
             N->quote
-                length(g) == N || error("g must be an array with exactly N elements (length(g) == "*string(length(g))*", N == "*string(N)*")")
+                length(g) == $N || error("g must be an array with exactly N elements (length(g) == "*string(length(g))*", N == "*string(N)*")")
                 $(extrap_transform_x(gr,eb,N))
                 $(define_indices(it,N))
                 @nexprs $N dim->begin

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -131,6 +131,8 @@ for IT in (
         Linear{OnCell},
         Quadratic{Flat,OnCell},
         Quadratic{Flat,OnGrid},
+        Quadratic{Reflect,OnCell},
+        Quadratic{Reflect,OnGrid},
         Quadratic{Line,OnGrid},
         Quadratic{Line,OnCell},
         Quadratic{Free,OnGrid},

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -193,7 +193,7 @@ for IT in (
 
         # Define in-place gradient calculation
         #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
-        eval(ngenerate(:N, :T, :(gradient!{T,N,TCoefs,TIndex}(g::Array{T,1}, itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N,TIndex}...)),
+        eval(ngenerate(:N, :(Vector{TOut}), :(gradient!{T,N,TCoefs}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,$IT,$EB}, x::NTuple{N}...)),
             N->quote
                 length(g) == N || error("g must be an array with exactly N elements (length(g) == "*string(length(g))*", N == "*string(N)*")")
                 $(extrap_transform_x(gr,eb,N))

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -1,5 +1,5 @@
-type ConstantDegree <: Degree{0} end
-type Constant{GR<:GridRepresentation} <: InterpolationType{ConstantDegree,None,GR} end
+immutable ConstantDegree <: Degree{0} end
+immutable Constant{GR<:GridRepresentation} <: InterpolationType{ConstantDegree,None,GR} end
 Constant{GR<:GridRepresentation}(::GR) = Constant{GR}()
 
 function define_indices(::Constant, N)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -3,7 +3,7 @@ immutable Constant{GR<:GridRepresentation} <: InterpolationType{ConstantDegree,N
 Constant{GR<:GridRepresentation}(::GR) = Constant{GR}()
 
 function define_indices(::Constant, N)
-    :(@nexprs $N d->(ix_d = clamp(round(Int,x_d), 1, size(itp,d))))
+    :(@nexprs $N d->(ix_d = clamp(round(real(x_d)), 1, size(itp,d))))
 end
 
 function coefficients(c::Constant, N)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -12,12 +12,12 @@ end
 
 function coefficients(::Constant, N, d)
     sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
-    :($sym = one(typeof($symx)))
+    :($sym = one(TIndex))
 end
 
 function gradient_coefficients(::Constant, N, d)
     sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
-    :($sym = zero(typeof($symx)))
+    :($sym = zero(TIndex))
 end
 
 function index_gen(degree::ConstantDegree, N::Integer, offsets...)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -12,12 +12,12 @@ end
 
 function coefficients(::Constant, N, d)
     sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
-    :($sym = one(TIndex))
+    :($sym = 1)
 end
 
 function gradient_coefficients(::Constant, N, d)
     sym, symx = symbol(string("c_",d)), symbol(string("x_",d))
-    :($sym = zero(TIndex))
+    :($sym = 0)
 end
 
 function index_gen(degree::ConstantDegree, N::Integer, offsets...)

--- a/src/extrapolation.jl
+++ b/src/extrapolation.jl
@@ -82,18 +82,7 @@ end
 
 immutable ExtrapPeriodic <: ExtrapolationBehavior end
 function extrap_transform_x(::GridRepresentation, ::ExtrapPeriodic, N)
-    quote
-        @nexprs $N d->begin
-            # translate x_d to inside the domain
-            n = convert(typeof(x_d), size(itp,d))
-            while x_d < .5
-                x_d += n
-            end
-            while x_d >= n + .5
-                x_d -= n
-            end
-        end
-    end
+    :(@nexprs $N d->(x_d = mod1(x_d, size(itp,d))))
 end
 
 immutable ExtrapLinear <: ExtrapolationBehavior end

--- a/src/extrapolation.jl
+++ b/src/extrapolation.jl
@@ -1,6 +1,6 @@
 abstract ExtrapolationBehavior
 
-type ExtrapError <: ExtrapolationBehavior end
+immutable ExtrapError <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapError, N)
     quote
         @nexprs $N d->(1 <= x_d <= size(itp,d) || throw(BoundsError()))
@@ -12,7 +12,7 @@ function extrap_transform_x(::OnCell, ::ExtrapError, N)
     end
 end
 
-type ExtrapNaN <: ExtrapolationBehavior end
+immutable ExtrapNaN <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapNaN, N)
     quote
         @nexprs $N d->(1 <= x_d <= size(itp,d) || return convert(T, NaN))
@@ -24,7 +24,7 @@ function extrap_transform_x(::OnCell, ::ExtrapNaN, N)
     end
 end
 
-type ExtrapConstant <: ExtrapolationBehavior end
+immutable ExtrapConstant <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapConstant, N)
     quote
         @nexprs $N d->(x_d = clamp(x_d, 1, size(itp,d)))
@@ -36,7 +36,7 @@ function extrap_transform_x(::OnCell, ::ExtrapConstant, N)
     end
 end
 
-type ExtrapReflect <: ExtrapolationBehavior end
+immutable ExtrapReflect <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapReflect, N)
     quote
         @nexprs $N d->begin
@@ -80,7 +80,7 @@ function extrap_transform_x(::OnCell, ::ExtrapReflect, N)
     end
 end
 
-type ExtrapPeriodic <: ExtrapolationBehavior end
+immutable ExtrapPeriodic <: ExtrapolationBehavior end
 function extrap_transform_x(::GridRepresentation, ::ExtrapPeriodic, N)
     quote
         @nexprs $N d->begin
@@ -96,7 +96,7 @@ function extrap_transform_x(::GridRepresentation, ::ExtrapPeriodic, N)
     end
 end
 
-type ExtrapLinear <: ExtrapolationBehavior end
+immutable ExtrapLinear <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapLinear, N)
     quote
         @nexprs $N d->begin

--- a/src/extrapolation.jl
+++ b/src/extrapolation.jl
@@ -3,24 +3,24 @@ abstract ExtrapolationBehavior
 immutable ExtrapError <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapError, N)
     quote
-        @nexprs $N d->(1 <= x_d <= size(itp,d) || throw(BoundsError()))
+        @nexprs $N d->(1 <= real(x_d) <= size(itp,d) || throw(BoundsError()))
     end
 end
 function extrap_transform_x(::OnCell, ::ExtrapError, N)
     quote
-        @nexprs $N d->(.5 <= x_d <= size(itp,d) + .5 || throw(BoundsError()))
+        @nexprs $N d->(.5 <= real(x_d) <= size(itp,d) + .5 || throw(BoundsError()))
     end
 end
 
 immutable ExtrapNaN <: ExtrapolationBehavior end
 function extrap_transform_x(::OnGrid, ::ExtrapNaN, N)
     quote
-        @nexprs $N d->(1 <= x_d <= size(itp,d) || return convert(T, NaN))
+        @nexprs $N d->(1 <= real(x_d) <= size(itp,d) || return convert(T, NaN))
     end
 end
 function extrap_transform_x(::OnCell, ::ExtrapNaN, N)
     quote
-        @nexprs $N d->(.5 <= x_d <= size(itp,d) + .5 || return convert(T, NaN))
+        @nexprs $N d->(.5 <= real(x_d) <= size(itp,d) + .5 || return convert(T, NaN))
     end
 end
 

--- a/src/extrapolation.jl
+++ b/src/extrapolation.jl
@@ -8,7 +8,7 @@ function extrap_transform_x(::OnGrid, ::ExtrapError, N)
 end
 function extrap_transform_x(::OnCell, ::ExtrapError, N)
     quote
-        @nexprs $N d->(.5 <= real(x_d) <= size(itp,d) + .5 || throw(BoundsError()))
+        @nexprs $N d->(1//2 <= real(x_d) <= size(itp,d) + 1//2 || throw(BoundsError()))
     end
 end
 
@@ -20,7 +20,7 @@ function extrap_transform_x(::OnGrid, ::ExtrapNaN, N)
 end
 function extrap_transform_x(::OnCell, ::ExtrapNaN, N)
     quote
-        @nexprs $N d->(.5 <= real(x_d) <= size(itp,d) + .5 || return convert(T, NaN))
+        @nexprs $N d->(1//2 <= real(x_d) <= size(itp,d) + 1//2 || return convert(T, NaN))
     end
 end
 
@@ -32,7 +32,7 @@ function extrap_transform_x(::OnGrid, ::ExtrapConstant, N)
 end
 function extrap_transform_x(::OnCell, ::ExtrapConstant, N)
     quote
-        @nexprs $N d->(x_d = clamp(x_d, .5, size(itp,d)+.5))
+        @nexprs $N d->(x_d = clamp(x_d, 1//2, size(itp,d)+1//2))
     end
 end
 

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -1,5 +1,5 @@
-type LinearDegree <: Degree{1} end
-type Linear{GR<:GridRepresentation} <: InterpolationType{LinearDegree,None,GR} end
+immutable LinearDegree <: Degree{1} end
+immutable Linear{GR<:GridRepresentation} <: InterpolationType{LinearDegree,None,GR} end
 Linear{GR<:GridRepresentation}(::GR) = Linear{GR}()
 
 function define_indices(::Linear, N)

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -5,7 +5,7 @@ Linear{GR<:GridRepresentation}(::GR) = Linear{GR}()
 function define_indices(::Linear, N)
     quote
         @nexprs $N d->begin
-            ix_d = clamp(floor(x_d), 1, size(itp,d)-1)
+            ix_d = clamp(floor(real(x_d)), 1, size(itp,d)-1)
             ixp_d = ix_d + 1
             fx_d = x_d - ix_d
         end

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -6,7 +6,7 @@ function define_indices(::Linear, N)
     quote
         @nexprs $N d->begin
             ix_d = clamp(floor(x_d), 1, size(itp,d)-1)
-            ixp_d = ix_d + one(typeof(ix_d))
+            ixp_d = ix_d + 1
             fx_d = x_d - ix_d
         end
     end
@@ -19,7 +19,7 @@ end
 function coefficients(::Linear, N, d)
     sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
     quote
-        $sym = one(typeof($symfx)) - $symfx
+        $sym = one(TIndex) - $symfx
         $symp = $symfx
     end
 end
@@ -27,8 +27,8 @@ end
 function gradient_coefficients(::Linear,N,d)
     sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
     quote
-        $sym = -one(typeof($symfx))
-        $symp = one(typeof($symfx))
+        $sym = -one(TIndex)
+        $symp = one(TIndex)
     end
 end
 

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -19,7 +19,7 @@ end
 function coefficients(::Linear, N, d)
     sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
     quote
-        $sym = one(TIndex) - $symfx
+        $sym = 1 - $symfx
         $symp = $symfx
     end
 end
@@ -27,8 +27,8 @@ end
 function gradient_coefficients(::Linear,N,d)
     sym, symp, symfx = symbol(string("c_",d)), symbol(string("cp_",d)), symbol(string("fx_",d))
     quote
-        $sym = -one(TIndex)
-        $symp = one(TIndex)
+        $sym = -1
+        $symp = 1
     end
 end
 

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -5,9 +5,9 @@ Linear{GR<:GridRepresentation}(::GR) = Linear{GR}()
 function define_indices(::Linear, N)
     quote
         @nexprs $N d->begin
-            ix_d = clamp(floor(Int,x_d), 1, size(itp,d)-1)
-            ixp_d = ix_d + 1
-            fx_d = x_d - convert(typeof(x_d), ix_d)
+            ix_d = clamp(floor(x_d), 1, size(itp,d)-1)
+            ixp_d = ix_d + one(typeof(ix_d))
+            fx_d = x_d - ix_d
         end
     end
 end

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -36,9 +36,9 @@ function coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = 1//2 * ($symfx - 1//2)^2
-        $sym  = 3//4 - $symfx^2
-        $symp = 1//2 * ($symfx + 1//2)^2
+        $symm = convert(T, 1//2 * ($symfx - 1//2)^2)
+        $sym  = convert(T, 3//4 - $symfx^2)
+        $symp = convert(T, 1//2 * ($symfx + 1//2)^2)
     end
 end
 
@@ -46,9 +46,9 @@ function gradient_coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = $symfx - 1//2
-        $sym = -2 * $symfx
-        $symp = $symfx + 1//2
+        $symm = convert(T, $symfx - 1//2)
+        $sym = convert(T, -2 * $symfx)
+        $symp = convert(T, $symfx + 1//2)
     end
 end
 
@@ -75,8 +75,8 @@ padding(::Quadratic) = 1
 padding(::Quadratic{Periodic}) = 0
 
 function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
-    du = fill(1//8, n-1)
-    d = fill(3//4, n)
+    du = fill(convert(T, 1//8), n-1)
+    d = fill(convert(T, 3//4), n)
     dl = copy(du)
     (dl,d,du)
 end

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -36,9 +36,9 @@ function coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(T, 1//2 * ($symfx - 1//2)^2)
-        $sym  = convert(T, 3//4 - $symfx^2)
-        $symp = convert(T, 1//2 * ($symfx + 1//2)^2)
+        $symm = 1//2 * ($symfx - 1//2)^2
+        $sym  = 3//4 - $symfx^2
+        $symp = 1//2 * ($symfx + 1//2)^2
     end
 end
 
@@ -46,9 +46,9 @@ function gradient_coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(T, $symfx - 1//2)
-        $sym = convert(T, -2 * $symfx)
-        $symp = convert(T, $symfx + 1//2)
+        $symm = $symfx - 1//2
+        $sym = -2 * $symfx
+        $symp = $symfx + 1//2
     end
 end
 

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -36,9 +36,9 @@ function coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, 1//2 * ($symfx - 1//2)^2)
-        $sym  = convert(TIndex, 3//4 - $symfx^2)
-        $symp = convert(TIndex, 1//2 * ($symfx + 1//2)^2)
+        $symm = 1//2 * ($symfx - 1//2)^2
+        $sym  = 3//4 - $symfx^2
+        $symp = 1//2 * ($symfx + 1//2)^2
     end
 end
 
@@ -46,9 +46,9 @@ function gradient_coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, $symfx - 1//2)
-        $sym = convert(TIndex, -2 * $symfx)
-        $symp = convert(TIndex, $symfx + 1//2)
+        $symm = $symfx - 1//2
+        $sym = -2 * $symfx
+        $symp = $symfx + 1//2
     end
 end
 
@@ -75,67 +75,67 @@ padding(::Quadratic) = 1
 padding(::Quadratic{Periodic}) = 0
 
 function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
-    du = fill(convert(T,1//8), n-1)
-    d = fill(convert(T,3//4),n)
+    du = fill(1//8, n-1)
+    d = fill(3//4, n)
     dl = copy(du)
     (dl,d,du)
 end
 
-function prefiltering_system{TCoefs,TIndex,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{TIndex}, n::Int, q::Quadratic{BC,OnCell})
-    dl,d,du = inner_system_diags(TIndex,n,q)
+function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{BC,OnCell})
+    dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
     lufact!(Tridiagonal(dl, d, du)), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,TIndex,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{TIndex}, n::Int, q::Quadratic{BC,OnGrid})
-    dl,d,du = inner_system_diags(TIndex,n,q)
+function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{BC,OnGrid})
+    dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 0
 
-    rowspec = zeros(TIndex,n,2)
+    rowspec = zeros(T,n,2)
     # first row     last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(TIndex,2,n)
+    colspec = zeros(T,2,n)
     # third col     third-to-last col
     colspec[1,3] = colspec[2,n-2] = 1
-    valspec = zeros(TIndex,2,2)
+    valspec = zeros(T,2,2)
     # [1,3]         [n,n-2]
     valspec[1,1] = valspec[2,2] = 1
 
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::Int, q::Quadratic{Line})
-    dl,d,du = inner_system_diags(TIndex,n,q)
+function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Line})
+    dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -2
 
-    rowspec = zeros(TIndex,n,2)
+    rowspec = zeros(T,n,2)
     # first row     last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(TIndex,2,n)
+    colspec = zeros(T,2,n)
     # third col     third-to-last col
     colspec[1,3] = colspec[2,n-2] = 1
-    valspec = zeros(TIndex,2,2)
+    valspec = zeros(T,2,2)
     # [1,3]         [n,n-2]
     valspec[1,1] = valspec[2,2] = 1
 
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::Int, q::Quadratic{Free})
-    dl,d,du = inner_system_diags(TIndex,n,q)
+function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Free})
+    dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -3
 
-    rowspec = zeros(TIndex,n,4)
+    rowspec = zeros(T,n,4)
     # first row     first row       last row       last row
     rowspec[1,1] = rowspec[1,2] = rowspec[n,3] = rowspec[n,4] = 1
-    colspec = zeros(TIndex,4,n)
+    colspec = zeros(T,4,n)
     # third col     fourth col     third-to-last col  fourth-to-last col
     colspec[1,3] = colspec[2,4] = colspec[3,n-2] = colspec[4,n-3] = 1
-    valspec = zeros(TIndex,4,4)
+    valspec = zeros(T,4,4)
     # [1,3]          [n,n-2]
     valspec[1,1] = valspec[3,3] = 3
     # [1,4]          [n,n-3]
@@ -144,16 +144,16 @@ function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::I
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::Int, q::Quadratic{Periodic})
-    dl,d,du = inner_system_diags(TIndex,n,q)
+function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Periodic})
+    dl,d,du = inner_system_diags(T,n,q)
 
-    rowspec = zeros(TIndex,n,2)
+    rowspec = zeros(T,n,2)
     # first row       last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(TIndex,2,n)
+    colspec = zeros(T,2,n)
     # last col         first col
     colspec[1,n] = colspec[2,1] = 1
-    valspec = zeros(TIndex,2,2)
+    valspec = zeros(T,2,2)
     # [1,n]            [n,1]
     valspec[1,1] = valspec[2,2] = 1//8
 

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -81,14 +81,14 @@ function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
     (dl,d,du)
 end
 
-function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnCell})
+function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnCell})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
     lufact!(Tridiagonal(dl, d, du)), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnGrid})
+function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnGrid})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 0
@@ -106,7 +106,7 @@ function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Line})
+function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Line})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -2
@@ -124,7 +124,7 @@ function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Qua
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Free})
+function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Free})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -3
@@ -144,7 +144,7 @@ function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Qua
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Periodic})
+function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Periodic})
     dl,d,du = inner_system_diags(T,n,q)
 
     rowspec = zeros(T,n,2)

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -7,7 +7,7 @@ function define_indices(q::Quadratic, N)
     quote
         pad = padding($q)
         @nexprs $N d->begin
-            ix_d = clamp(round(x_d), 1, size(itp,d)) + pad
+            ix_d = clamp(round(real(x_d)), 1, size(itp,d)) + pad
             ixp_d = ix_d + 1
             ixm_d = ix_d - 1
 
@@ -19,7 +19,7 @@ function define_indices(q::Quadratic{Periodic}, N)
     quote
         pad = padding($q)
         @nexprs $N d->begin
-            ix_d = clamp(round(x_d), 1, size(itp,d)) + pad
+            ix_d = clamp(round(real(x_d)), 1, size(itp,d)) + pad
             ixp_d = mod1(ix_d + 1, size(itp,d))
             ixm_d = mod1(ix_d - 1, size(itp,d))
 

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -81,14 +81,14 @@ function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
     (dl,d,du)
 end
 
-function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{BC,OnCell})
+function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnCell})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
     lufact!(Tridiagonal(dl, d, du)), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{BC,OnGrid})
+function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnGrid})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 0
@@ -106,7 +106,7 @@ function prefiltering_system{TCoefs,T,BC<:Union(Flat,Reflect)}(::Type{TCoefs}, :
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Line})
+function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Line})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -2
@@ -124,7 +124,7 @@ function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Qua
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Free})
+function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Free})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = 1
     du[1] = dl[end] = -3
@@ -144,7 +144,7 @@ function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Qua
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{TCoefs,T}(::Type{TCoefs}, ::Type{T}, n::Int, q::Quadratic{Periodic})
+function prefiltering_system{TCoefs,T}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Periodic})
     dl,d,du = inner_system_diags(T,n,q)
 
     rowspec = zeros(T,n,2)

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -1,5 +1,5 @@
-type QuadraticDegree <: Degree{2} end
-type Quadratic{BC<:BoundaryCondition,GR<:GridRepresentation} <: InterpolationType{QuadraticDegree,BC,GR} end
+immutable QuadraticDegree <: Degree{2} end
+immutable Quadratic{BC<:BoundaryCondition,GR<:GridRepresentation} <: InterpolationType{QuadraticDegree,BC,GR} end
 
 Quadratic{BC<:BoundaryCondition,GR<:GridRepresentation}(::BC, ::GR) = Quadratic{BC,GR}()
 

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -36,9 +36,9 @@ function coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, .5 * ($symfx - .5)^2)
-        $sym  = convert(TIndex, .75 - $symfx^2)
-        $symp = convert(TIndex, .5 * ($symfx + .5)^2)
+        $symm = convert(TIndex, 1//2 * ($symfx - 1//2)^2)
+        $sym  = convert(TIndex, 3//4 - $symfx^2)
+        $symp = convert(TIndex, 1//2 * ($symfx + 1//2)^2)
     end
 end
 
@@ -46,9 +46,9 @@ function gradient_coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, $symfx - .5)
+        $symm = convert(TIndex, $symfx - 1//2)
         $sym = convert(TIndex, -2 * $symfx)
-        $symp = convert(TIndex, $symfx + .5)
+        $symp = convert(TIndex, $symfx + 1//2)
     end
 end
 
@@ -75,8 +75,8 @@ padding(::Quadratic) = 1
 padding(::Quadratic{Periodic}) = 0
 
 function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
-    du = fill(convert(T,1/8), n-1)
-    d = fill(convert(T,3/4),n)
+    du = fill(convert(T,1//8), n-1)
+    d = fill(convert(T,3//4),n)
     dl = copy(du)
     (dl,d,du)
 end
@@ -155,7 +155,7 @@ function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::I
     colspec[1,n] = colspec[2,1] = 1
     valspec = zeros(TIndex,2,2)
     # [1,n]            [n,1]
-    valspec[1,1] = valspec[2,2] = 1/8
+    valspec[1,1] = valspec[2,2] = 1//8
 
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -9,8 +9,13 @@ g1(x) = 2pi/(nx-1) * cos((x-3)*2pi/(nx-1) - 1)
 # Gradient of Constant should always be 0
 itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Constant(OnGrid()), ExtrapPeriodic())
+
+g = Array(Float64, 1)
+
 for x in 1:nx
     @test gradient(itp1, x)[1] == 0
+    @test gradient!(g, itp1, x)[1] == 0
+    @test g[1] == 0
 end
 
 # Since Linear is OnGrid in the domain, check the gradients between grid points
@@ -18,6 +23,8 @@ itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Linear(OnGrid()), ExtrapPeriodic())
 for x in 2.5:nx-1.5
     @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.1*g1(x))
+    @test_approx_eq_eps g1(x) gradient!(g, itp1, x)[1] abs(.1*g1(x))
+    @test_approx_eq_eps g1(x) g[1] abs(.1*g1(x))
 end
 
 # Since Quadratic is OnCell in the domain, check gradients at grid points
@@ -25,6 +32,8 @@ itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Quadratic(Periodic(),OnGrid()), ExtrapPeriodic())
 for x in 2:nx-1
     @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.05*g1(x))
+    @test_approx_eq_eps g1(x) gradient!(g, itp1, x)[1] abs(.05*g1(x))
+    @test_approx_eq_eps g1(x) g[1] abs(.1*g1(x))
 end
 
 end

--- a/test/linear.jl
+++ b/test/linear.jl
@@ -42,6 +42,11 @@ xlo, xhi = itp3[.9], itp3[xmax+.2]
 @test xlo == A[1]
 @test xhi == A[end]
 
+# Rational element types
+A = Rational{Int}[x//10+2 for x in 1:10]
+itp = Interpolation(A, Linear(OnGrid()), ExtrapNaN())
+@test itp[11//10] == (11//10)//10+2
+
 end
 
 module Linear2DTests

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -44,7 +44,7 @@ for x in [3.1:.2:4.3]
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
-xlo, xhi = itp3[.9], itp3[xmax+.2]
+xlo, xhi = itp3[.2], itp3[xmax+.7]
 @test_approx_eq xlo A[1]
 @test_approx_eq xhi A[end]
 

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -63,11 +63,6 @@ for x in 2:xmax-1
     @test_approx_eq A[x] itp3[x]
 end
 
-# Rational element types
-A = Rational{Int}[x^2//10 for x in 1:10]
-itp = Interpolation(A, Quadratic(Free(),OnCell()), ExtrapNaN())
-@test itp[11//10] == (11//10)^2//10
-
 end
 
 module Quadratic2DTests

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -12,7 +12,7 @@ A = Float64[f(x) for x in 1:xmax]
 
 itp1 = Interpolation(A, Quadratic(Flat(),OnCell()), ExtrapError())
 
-for x in [3.1:.2:4.3]  
+for x in [3.1:.2:4.3]
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
@@ -62,6 +62,11 @@ for x in 2:xmax-1
     @test_approx_eq A[x] itp2[x]
     @test_approx_eq A[x] itp3[x]
 end
+
+# Rational element types
+A = Rational{Int}[x^2//10 for x in 1:10]
+itp = Interpolation(A, Quadratic(Free(),OnCell()), ExtrapNaN())
+@test itp[11//10] == (11//10)^2//10
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,9 @@ include("on-grid.jl")
 # test gradient evaluation
 include("gradient.jl")
 
+# test interpolation with specific types
+include("typing.jl")
+
 # Tests copied from Grid.jl's old test suite
 #include("grid.jl")
 

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -1,0 +1,30 @@
+module TypingTests
+
+using Interpolations, Base.Test
+
+nx = 10
+f(x) = convert(Float32, x^3/(nx-1))
+g(x) = convert(Float32, 3x^2/(nx-1))
+
+A = Float32[f(x) for x in 1:nx]
+
+itp = Interpolation(A, Quadratic(Flat(), OnCell()), ExtrapConstant())
+
+# display(plot(
+#     layer(x=1:nx,y=[f(x) for x in 1:1//1:nx],Geom.point),
+#     layer(x=1:.1:nx,y=[itp[x] for x in 1:1//10:nx],Geom.path),
+# ))
+
+for x in [3.1:.2:4.3]
+    @test_approx_eq_eps float(f(x)) float(itp[x]) abs(.1*f(x))
+end
+
+@test typeof(itp[3.5]) == Float32
+
+for x in [3.1:.2:4.3]
+    @test_approx_eq_eps g(x) gradient(itp, x) abs(.1*g(x))
+end
+
+@test typeof(gradient(itp, 3.5)[1]) == Float32
+
+end

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -19,7 +19,7 @@ for x in [3.1:.2:4.3]
     @test_approx_eq_eps float(f(x)) float(itp[x]) abs(.1*f(x))
 end
 
-@test typeof(itp[3.5]) == Float32
+@test typeof(itp[3.5f0]) == Float32
 
 for x in [3.1:.2:4.3]
     @test_approx_eq_eps g(x) gradient(itp, x) abs(.1*g(x))

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -27,4 +27,11 @@ end
 
 @test typeof(gradient(itp, 3.5)[1]) == Float32
 
+if Base.VERSION >= v"0.4-" # This doesn't work on 0.3 due to rational errors in linalg
+    # Rational element types
+    R = Rational{Int}[x^2//10 for x in 1:10]
+    itp = Interpolation(R, Quadratic(Free(),OnCell()), ExtrapNaN())
+    @test itp[11//10] == (11//10)^2//10
+end
+
 end


### PR DESCRIPTION
This is a first attempt at a solution to #17, but it doesn't work quite yet:

```julia
julia> using Interpolations

julia> include("test/runtests.jl")
Testing Linear interpolation in 1D...
ERROR: test failed: itp1[-3]
 in error at error.jl:21
 in default_handler at test.jl:19
 in do_test_throws at test.jl:55
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
while loading /home/tlycken/.julia/v0.3/Interpolations/test/linear.jl, in expression starting on line 19
while loading /home/tlycken/.julia/v0.3/Interpolations/test/runtests.jl, in expression starting on line 7
```

The line in question is 

```
@test_throws BoundsError itp1[-3]
```

which happens to be the first time the interpolation object is indexed into with an `Int` - all previous versions calls have indexed with a float...

However, from what I can tell there *should* be a suitable indexing method defined - I thought I did so [here](https://github.com/tlycken/Interpolations.jl/commit/345b28f8928535b6c1f6a450f0f5d84b76feac6a#diff-188e9d45a6f52c11943b00a6d109d98fR168). Also, `methods` seems a little confused - shouldn't `x` be an `NTuple` here?

```julia
julia> methods(getindex, (Interpolation{Float64,1,Float64,Linear{OnGrid},ExtrapError},))
1-element Array{Any,1}:
 getindex{T,N,TCoefs<:Real}(itp::Interpolation{T,N,TCoefs<:Real,Linear{OnGrid},ExtrapError},x::TCoefs<:Real...) at cartesian.jl:100
```

