### PR TITLE
Reflecting BC for quadratic itp

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -27,6 +27,7 @@ export
     Line,
     Free,
     Periodic,
+    Reflect,
 
     degree,
     boundarycondition,
@@ -45,6 +46,7 @@ type Line <: BoundaryCondition end
 typealias Natural Line
 type Free <: BoundaryCondition end
 type Periodic <: BoundaryCondition end
+immutable Reflect <: BoundaryCondition end
 
 abstract InterpolationType{D<:Degree,BC<:BoundaryCondition,GR<:GridRepresentation}
 
@@ -117,6 +119,8 @@ for IT in (
         Linear{OnCell},
         Quadratic{Flat,OnCell},
         Quadratic{Flat,OnGrid},
+        Quadratic{Reflect,OnCell},
+        Quadratic{Reflect,OnGrid},
         Quadratic{Line,OnGrid},
         Quadratic{Line,OnCell},
         Quadratic{Free,OnGrid},
@@ -186,6 +190,8 @@ gradient{T}(itp::Interpolation{T}, x...) = gradient!(Array(T,ndims(itp)), itp, x
 for IT in (
         Quadratic{Flat,OnCell},
         Quadratic{Flat,OnGrid},
+        Quadratic{Reflect,OnCell},
+        Quadratic{Reflect,OnGrid},
         Quadratic{Line,OnGrid},
         Quadratic{Line,OnCell},
         Quadratic{Free,OnGrid},

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -81,14 +81,14 @@ function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
     (dl,d,du)
 end
 
-function prefiltering_system{T}(::Type{T}, n::Int, q::Quadratic{Flat,OnCell})
+function prefiltering_system{T,BC<:Union(Flat,Reflect)}(::Type{T}, n::Int, q::Quadratic{BC,OnCell})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
     lufact!(Tridiagonal(dl, d, du)), zeros(T, n)
 end
 
-function prefiltering_system{T}(::Type{T}, n::Int, q::Quadratic{Flat,OnGrid})
+function prefiltering_system{T,BC<:Union(Flat,Reflect)}(::Type{T}, n::Int, q::Quadratic{BC,OnGrid})
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = convert(T, -1)
     du[1] = dl[end] = convert(T, 0)

--- a/test/on-grid.jl
+++ b/test/on-grid.jl
@@ -13,7 +13,7 @@ f3(x,y,z) = f2(x,y) * log(z)
 simpledegs = (Linear,Constant)
 bcdegs = (Quadratic,)
 gridbehvs = (OnCell,OnGrid)
-bcs = (Flat,Line,Free,Periodic)
+bcs = (Flat,Line,Free,Periodic,Reflect)
 
 function OneD()
     println("Testing evaluation on grid and boundary in 1D...")


### PR DESCRIPTION
I realized that for quadratic interpolation, `Flat` (first derivative equal to zero
at edges) and `Reflect` (all continuous derivatives equal to zero at edges) are equivalent,
since the first derivative is the only continuous one for quadratic interpolation.
This just adds the `Reflect` option so you can do 

```
itp = Interpolation(A, Quadratic(Reflect(), OnCell()), ExtrapReflect())
```

which feels a little more intuitive than using `Flat` even though they're the same.