### PR TITLE
Support quadratic interpolation of Rational types

### DIFF
--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -36,9 +36,9 @@ function coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, .5 * ($symfx - .5)^2)
-        $sym  = convert(TIndex, .75 - $symfx^2)
-        $symp = convert(TIndex, .5 * ($symfx + .5)^2)
+        $symm = convert(TIndex, 1//2 * ($symfx - 1//2)^2)
+        $sym  = convert(TIndex, 3//4 - $symfx^2)
+        $symp = convert(TIndex, 1//2 * ($symfx + 1//2)^2)
     end
 end
 
@@ -46,9 +46,9 @@ function gradient_coefficients(q::Quadratic, N, d)
     symm, sym, symp =  symbol(string("cm_",d)), symbol(string("c_",d)), symbol(string("cp_",d))
     symfx = symbol(string("fx_",d))
     quote
-        $symm = convert(TIndex, $symfx - .5)
+        $symm = convert(TIndex, $symfx - 1//2)
         $sym = convert(TIndex, -2 * $symfx)
-        $symp = convert(TIndex, $symfx + .5)
+        $symp = convert(TIndex, $symfx + 1//2)
     end
 end
 
@@ -75,8 +75,8 @@ padding(::Quadratic) = 1
 padding(::Quadratic{Periodic}) = 0
 
 function inner_system_diags{T}(::Type{T}, n::Int, ::Quadratic)
-    du = fill(convert(T,1/8), n-1)
-    d = fill(convert(T,3/4),n)
+    du = fill(convert(T,1//8), n-1)
+    d = fill(convert(T,3//4),n)
     dl = copy(du)
     (dl,d,du)
 end
@@ -155,7 +155,7 @@ function prefiltering_system{TCoefs,TIndex}(::Type{TCoefs}, ::Type{TIndex}, n::I
     colspec[1,n] = colspec[2,1] = 1
     valspec = zeros(TIndex,2,2)
     # [1,n]            [n,1]
-    valspec[1,1] = valspec[2,2] = 1/8
+    valspec[1,1] = valspec[2,2] = 1//8
 
     Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
 end

--- a/test/linear.jl
+++ b/test/linear.jl
@@ -42,6 +42,11 @@ xlo, xhi = itp3[.9], itp3[xmax+.2]
 @test xlo == A[1]
 @test xhi == A[end]
 
+# Rational element types
+A = Rational{Int}[x//10+2 for x in 1:10]
+itp = Interpolation(A, Linear(OnGrid()), ExtrapNaN())
+@test itp[11//10] == (11//10)//10+2
+
 end
 
 module Linear2DTests

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -12,7 +12,7 @@ A = Float64[f(x) for x in 1:xmax]
 
 itp1 = Interpolation(A, Quadratic(Flat(),OnCell()), ExtrapError())
 
-for x in [3.1:.2:4.3]  
+for x in [3.1:.2:4.3]
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
@@ -62,6 +62,11 @@ for x in 2:xmax-1
     @test_approx_eq A[x] itp2[x]
     @test_approx_eq A[x] itp3[x]
 end
+
+# Rational element types
+A = Rational{Int}[x^2//10 for x in 1:10]
+itp = Interpolation(A, Quadratic(Free(),OnCell()), ExtrapNaN())
+@test itp[11//10] == (11//10)^2//10
 
 end
 


### PR DESCRIPTION
Note this is a pull request against your `handling-of-types` branch, not `master`.

The only real problem with Rationals was we were getting (on julia 0.4) `Overflow` errors. That turns out to be because any little floating-point imprecision was causing conversion to "big" rationals:
```julia
julia> convert(Rational, 0.4)
3602879701896397//9007199254740992
```
