### PR TITLE
WIP: convert to stagedfunctions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: julia
-julia: 
-    - release 
+julia:
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
+julia 0.4-
 Compat
+WoodburyMatrices

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -174,7 +174,7 @@ end
 # Resolve ambiguity with real multilinear indexing
 stagedfunction getindex{T,N,TCoefs,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::Real...)
     n = length(x)
-    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
+    n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     getindex_impl(N, IT, EB)
 end
 
@@ -193,7 +193,7 @@ end
 # Allow multilinear indexing with any types
 stagedfunction getindex{T,N,TCoefs,TIndex,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::TIndex...)
     n = length(x)
-    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
+    n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     getindex_impl(N, IT, EB)
 end
 
@@ -201,11 +201,11 @@ end
 #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
 stagedfunction gradient!{T,N,TCoefs,TOut,IT,EB}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,IT,EB}, x...)
     n = length(x)
-    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
+    n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     it = IT()
     eb = EB()
     gr = gridrepresentation(it)
-    q = quote
+    quote
         length(g) == $N || error("g must be an array with exactly N elements (length(g) == "*string(length(g))*", N == "*string($N)*")")
         @nexprs $N d->(x_d = x[d])
         $(extrap_transform_x(gr,eb,N))
@@ -218,11 +218,8 @@ stagedfunction gradient!{T,N,TCoefs,TOut,IT,EB}(g::Vector{TOut}, itp::Interpolat
 
             @inbounds g[dim] = $(index_gen(degree(it),N))
         end
-        @show g
         g
     end
-    # @show q
-    q
 end
 
 gradient{T,N}(itp::Interpolation{T,N}, x...) = gradient!(Array(T,N), itp, x...)

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -174,7 +174,7 @@ end
 # Resolve ambiguity with real multilinear indexing
 stagedfunction getindex{T,N,TCoefs,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::Real...)
     n = length(x)
-    n == N || return :(error("Must index interpolation objects with as many indexes as dimensions"))
+    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
     getindex_impl(N, IT, EB)
 end
 
@@ -193,7 +193,7 @@ end
 # Allow multilinear indexing with any types
 stagedfunction getindex{T,N,TCoefs,TIndex,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::TIndex...)
     n = length(x)
-    n == N || return :(error("Must index interpolation objects with as many indexes as dimensions"))
+    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
     getindex_impl(N, IT, EB)
 end
 
@@ -201,7 +201,7 @@ end
 #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
 stagedfunction gradient!{T,N,TCoefs,TOut,IT,EB}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,IT,EB}, x...)
     n = length(x)
-    n == N || return :(error("Must index interpolation objects with as many indexes as dimensions"))
+    n == N || return :(error("Must index $N-dimensional interpolation objects with $(nindexes(N))"))
     it = IT()
     eb = EB()
     gr = gridrepresentation(it)
@@ -236,7 +236,7 @@ stagedfunction prefilter{TWeights,TCoefs,N,IT<:Quadratic}(::Type{TWeights}, A::A
         strds = collect(strides(ret))
 
         for dim in 1:$N
-             n = szs[dim]
+            n = szs[dim]
             szs[dim] = 1
 
             M, b = prefiltering_system(TWeights, TCoefs, n, it)
@@ -258,5 +258,7 @@ stagedfunction prefilter{TWeights,TCoefs,N,IT<:Quadratic}(::Type{TWeights}, A::A
         ret
     end
 end
+
+nindexes(N::Int) = N == 1 ? "1 index" : "$N indexes"
 
 end # module

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -28,7 +28,7 @@ for x in 2.5:nx-1.5
 end
 
 # Since Quadratic is OnCell in the domain, check gradients at grid points
-itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1], 
+itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Quadratic(Periodic(),OnGrid()), ExtrapPeriodic())
 for x in 2:nx-1
     @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.05*g1(x))

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -22,6 +22,7 @@ end
 itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Linear(OnGrid()), ExtrapPeriodic())
 for x in 2.5:nx-1.5
+    @show gradient!(g, itp1, x)
     @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.1*g1(x))
     @test_approx_eq_eps g1(x) gradient!(g, itp1, x)[1] abs(.1*g1(x))
     @test_approx_eq_eps g1(x) g[1] abs(.1*g1(x))

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -22,7 +22,6 @@ end
 itp1 = Interpolation(Float64[f1(x) for x in 1:nx-1],
             Linear(OnGrid()), ExtrapPeriodic())
 for x in 2.5:nx-1.5
-    @show gradient!(g, itp1, x)
     @test_approx_eq_eps g1(x) gradient(itp1, x)[1] abs(.1*g1(x))
     @test_approx_eq_eps g1(x) gradient!(g, itp1, x)[1] abs(.1*g1(x))
     @test_approx_eq_eps g1(x) g[1] abs(.1*g1(x))

--- a/test/linear.jl
+++ b/test/linear.jl
@@ -12,7 +12,7 @@ A = Float64[f(x) for x in 1:xmax]
 
 itp1 = Interpolation(A, Linear(OnGrid()), ExtrapError())
 
-for x in [1:.2:xmax]
+for x in 1:.2:xmax
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
@@ -23,7 +23,7 @@ end
 
 itp2 = Interpolation(A, Linear(OnGrid()), ExtrapNaN())
 
-for x in [1:.2:xmax]
+for x in 1:.2:xmax
     @test_approx_eq_eps f(x) itp2[x] abs(.1*f(x))
 end
 
@@ -34,7 +34,7 @@ xlo, xhi = itp2[.9], itp2[xmax+.2]
 ## ExtrapConstant
 
 itp3 = Interpolation(A, Linear(OnGrid()), ExtrapConstant())
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps f(x) itp3[x] abs(.1*f(x))
 end
 

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -49,7 +49,7 @@ xlo, xhi = itp3[.2], itp3[xmax+.7]
 @test_approx_eq xhi A[end]
 
 # Check continuity
-xs = [0:.1:length(A)+1;]
+xs = 0:.1:length(A)+1
 
 for i in 1:length(xs)-1
     @test_approx_eq_eps itp3[xs[i]] itp3[xs[i+1]] .1

--- a/test/quadratic.jl
+++ b/test/quadratic.jl
@@ -12,7 +12,7 @@ A = Float64[f(x) for x in 1:xmax]
 
 itp1 = Interpolation(A, Quadratic(Flat(),OnCell()), ExtrapError())
 
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
@@ -23,7 +23,7 @@ end
 
 itp2 = Interpolation(A, Quadratic(Flat(),OnCell()), ExtrapNaN())
 
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps f(x) itp2[x] abs(.1*f(x))
 end
 
@@ -40,7 +40,7 @@ itp3 = Interpolation(A, Quadratic(Flat(),OnGrid()), ExtrapConstant())
 
 # Check inbounds and extrap values
 
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
 end
 
@@ -49,7 +49,7 @@ xlo, xhi = itp3[.2], itp3[xmax+.7]
 @test_approx_eq xhi A[end]
 
 # Check continuity
-xs = [0:.1:length(A)+1]
+xs = [0:.1:length(A)+1;]
 
 for i in 1:length(xs)-1
     @test_approx_eq_eps itp3[xs[i]] itp3[xs[i+1]] .1

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -15,13 +15,13 @@ itp = Interpolation(A, Quadratic(Flat(), OnCell()), ExtrapConstant())
 #     layer(x=1:.1:nx,y=[itp[x] for x in 1:1//10:nx],Geom.path),
 # ))
 
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps float(f(x)) float(itp[x]) abs(.1*f(x))
 end
 
 @test typeof(itp[3.5f0]) == Float32
 
-for x in [3.1:.2:4.3]
+for x in 3.1:.2:4.3
     @test_approx_eq_eps g(x) gradient(itp, x) abs(.1*g(x))
 end
 


### PR DESCRIPTION
This is a WIP to fix #21. It mostly works, and has a massively-beneficial impact on package loading time, but I am getting a truly bizarre error. I inserted some printing code to illustrate the problem:
```julia
julia> include("runtests.jl")
Testing Linear interpolation in 1D...
Testing Linear interpolation in 2D...
Testing Quadratic interpolation in 1D...
Testing Quadratic interpolation in 2D...
Testing evaluation on grid and boundary in 1D...
Testing evaluation on grid and boundary in 2D...
Testing evaluation on grid and boundary in 3D...
Testing gradient evaluation
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [-0.0]
g = [0.15043281484715354]
gradient!(g,itp1,x) = [-0.6782138028608058,-0.99190379965505,-0.8414709848078965,-0.2973045442608362,0.3859739967178289,0.8886510150090671,0.9755183471216421,0.6059298029372212,-0.04718003020117026]
g = [0.15043281484715354]
g = [0.15043281484715354]
ERROR: LoadError: LoadError: assertion failed: |g1(x) - (gradient!(g,itp1,x))[1]| <= 0.015353177135101162
  g1(x) = 0.15353177135101162
  (gradient!(g,itp1,x))[1] = 1
  difference = 0.8464682286489884 > 0.015353177135101162
 in error at error.jl:20
 in test_approx_eq at test.jl:137
 in anonymous at no file:27
 in include at ./boot.jl:249
 in include_from_node1 at ./loading.jl:128
 in include at ./boot.jl:249
 in include_from_node1 at ./loading.jl:128
while loading /home/tim/.julia/v0.4/Interpolations/test/gradient.jl, in expression starting on line 24
while loading /home/tim/.julia/v0.4/Interpolations/test/runtests.jl, in expression starting on line 16
```
Upon further investigation, despite [the code](https://github.com/tlycken/Interpolations.jl/blob/6cea519adfe9af4e7e118cb75f780a2302dc3999/src/Interpolations.jl#L222) `gradient!` is returning `itp1.coefs` rather than `g`, but only from the direct `gradient!` call and not from the `gradient` wrapper (which just calls `gradient!`). Also note that there's an inconsistency in ` (gradient!(g,itp1,x))[1] = 1` with `gradient!(g,itp1,x) = [-0.6782138028608058,-0.99190379965505,-0.8414709848078965,-0.2973045442608362,0.3859739967178289,0.8886510150090671,0.9755183471216421,0.6059298029372212,-0.04718003020117026]`.

I got to the point where I can't work on this any more tonight, and I'm pretty baffled. Any ideas? I suspect this is a bug in julia proper.