### PR TITLE
WIP: in-place interpolations

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -167,12 +167,12 @@ end
 # Resolve ambiguity with linear indexing
 getindex{T,N,TCoefs,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::Real) =
     error("Linear indexing is not supported for interpolation objects")
-stagedfunction getindex{T,TCoefs,IT,EB}(itp::Interpolation{T,1,TCoefs,IT,EB}, x::Real)
+@generated function getindex{T,TCoefs,IT,EB}(itp::Interpolation{T,1,TCoefs,IT,EB}, x::Real)
     getindex_impl(1, IT, EB)
 end
 
 # Resolve ambiguity with real multilinear indexing
-stagedfunction getindex{T,N,TCoefs,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::Real...)
+@generated function getindex{T,N,TCoefs,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::Real...)
     n = length(x)
     n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     getindex_impl(N, IT, EB)
@@ -191,7 +191,7 @@ function getindex{T,TCoefs,IT,EB}(itp::Interpolation{T,1,TCoefs,IT,EB}, c::Colon
 end
 
 # Allow multilinear indexing with any types
-stagedfunction getindex{T,N,TCoefs,TIndex,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::TIndex...)
+@generated function getindex{T,N,TCoefs,TIndex,IT,EB}(itp::Interpolation{T,N,TCoefs,IT,EB}, x::TIndex...)
     n = length(x)
     n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     getindex_impl(N, IT, EB)
@@ -199,7 +199,7 @@ end
 
 # Define in-place gradient calculation
 #   gradient!(g::Vector, itp::Interpolation, NTuple{N}...)
-stagedfunction gradient!{T,N,TCoefs,TOut,IT,EB}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,IT,EB}, x...)
+@generated function gradient!{T,N,TCoefs,TOut,IT,EB}(g::Vector{TOut}, itp::Interpolation{T,N,TCoefs,IT,EB}, x...)
     n = length(x)
     n == N || return :(error("Must index ", $N, "-dimensional interpolation objects with ", $(nindexes(N))))
     it = IT()
@@ -225,7 +225,7 @@ end
 gradient{T,N}(itp::Interpolation{T,N}, x...) = gradient!(Array(T,N), itp, x...)
 
 # This creates prefilter specializations for all interpolation types that need them
-stagedfunction prefilter{TWeights,TCoefs,N,IT<:Quadratic}(::Type{TWeights}, A::Array{TCoefs,N}, it::IT)
+@generated function prefilter{TWeights,TCoefs,N,IT<:Quadratic}(::Type{TWeights}, A::Array{TCoefs,N}, it::IT)
     quote
         ret, pad = copy_with_padding(A, it)
 

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -3,7 +3,7 @@ immutable Constant{GR<:GridRepresentation} <: InterpolationType{ConstantDegree,N
 Constant{GR<:GridRepresentation}(::GR) = Constant{GR}()
 
 function define_indices(::Constant, N)
-    :(@nexprs $N d->(ix_d = clamp(round(real(x_d)), 1, size(itp,d))))
+    :(@nexprs $N d->(ix_d = clamp(round(Int, real(x_d)), 1, size(itp,d))))
 end
 
 function coefficients(c::Constant, N)

--- a/src/extrapolation.jl
+++ b/src/extrapolation.jl
@@ -1,43 +1,43 @@
 abstract ExtrapolationBehavior
 
 immutable ExtrapError <: ExtrapolationBehavior end
-function extrap_transform_x(::OnGrid, ::ExtrapError, N)
+function extrap_transform_x(::OnGrid, ::ExtrapError, N, ::InterpolationType)
     quote
         @nexprs $N d->(1 <= real(x_d) <= size(itp,d) || throw(BoundsError()))
     end
 end
-function extrap_transform_x(::OnCell, ::ExtrapError, N)
+function extrap_transform_x(::OnCell, ::ExtrapError, N, ::InterpolationType)
     quote
         @nexprs $N d->(1//2 <= real(x_d) <= size(itp,d) + 1//2 || throw(BoundsError()))
     end
 end
 
 immutable ExtrapNaN <: ExtrapolationBehavior end
-function extrap_transform_x(::OnGrid, ::ExtrapNaN, N)
+function extrap_transform_x(::OnGrid, ::ExtrapNaN, N, ::InterpolationType)
     quote
         @nexprs $N d->(1 <= real(x_d) <= size(itp,d) || return convert(T, NaN))
     end
 end
-function extrap_transform_x(::OnCell, ::ExtrapNaN, N)
+function extrap_transform_x(::OnCell, ::ExtrapNaN, N, ::InterpolationType)
     quote
         @nexprs $N d->(1//2 <= real(x_d) <= size(itp,d) + 1//2 || return convert(T, NaN))
     end
 end
 
 immutable ExtrapConstant <: ExtrapolationBehavior end
-function extrap_transform_x(::OnGrid, ::ExtrapConstant, N)
+function extrap_transform_x(::OnGrid, ::ExtrapConstant, N, ::InterpolationType)
     quote
         @nexprs $N d->(x_d = clamp(x_d, 1, size(itp,d)))
     end
 end
-function extrap_transform_x(::OnCell, ::ExtrapConstant, N)
+function extrap_transform_x(::OnCell, ::ExtrapConstant, N, ::InterpolationType)
     quote
         @nexprs $N d->(x_d = clamp(x_d, 1//2, size(itp,d)+1//2))
     end
 end
 
 immutable ExtrapReflect <: ExtrapolationBehavior end
-function extrap_transform_x(::OnGrid, ::ExtrapReflect, N)
+function extrap_transform_x(::OnGrid, ::ExtrapReflect, N, ::InterpolationType)
     quote
         @nexprs $N d->begin
             # translate x_d to inside the domain, and count the translations
@@ -58,7 +58,7 @@ function extrap_transform_x(::OnGrid, ::ExtrapReflect, N)
         end
     end
 end
-function extrap_transform_x(::OnCell, ::ExtrapReflect, N)
+function extrap_transform_x(::OnCell, ::ExtrapReflect, N, ::InterpolationType)
     quote
         @nexprs $N d->begin
             # translate x_d to inside the domain, and count the translations
@@ -81,12 +81,12 @@ function extrap_transform_x(::OnCell, ::ExtrapReflect, N)
 end
 
 immutable ExtrapPeriodic <: ExtrapolationBehavior end
-function extrap_transform_x(::GridRepresentation, ::ExtrapPeriodic, N)
+function extrap_transform_x(::GridRepresentation, ::ExtrapPeriodic, N, ::InterpolationType)
     :(@nexprs $N d->(x_d = mod1(x_d, size(itp,d))))
 end
 
 immutable ExtrapLinear <: ExtrapolationBehavior end
-function extrap_transform_x(::OnGrid, ::ExtrapLinear, N)
+function extrap_transform_x(::OnGrid, ::ExtrapLinear, N, ::InterpolationType)
     quote
         @nexprs $N d->begin
             if x_d < 1
@@ -111,4 +111,4 @@ function extrap_transform_x(::OnGrid, ::ExtrapLinear, N)
         end
     end
 end
-extrap_transform_x(::OnCell, e::ExtrapLinear, N) = extrap_transform_x(OnGrid(), e, N)
+extrap_transform_x(::OnCell, e::ExtrapLinear, N, it::InterpolationType) = extrap_transform_x(OnGrid(), e, N, it)

--- a/src/filter1d.jl
+++ b/src/filter1d.jl
@@ -1,0 +1,140 @@
+import Base.LinAlg.LU, Base.getindex
+
+### Tridiagonal inversion along a particular dimension, first offsetting the values by b
+
+function A_ldiv_B_md!{T}(dest, F::LU{T,Tridiagonal{T}}, src, dim::Integer, b::AbstractVector)
+    1 <= dim <= max(ndims(dest),ndims(src)) || throw(DimensionMismatch("The chosen dimension $dim is larger than $(ndims(src)) and $(ndims(dest))"))
+    n = size(F, 1)
+    n == size(src, dim) && n == size(dest, dim) || throw(DimensionMismatch("Sizes $n, $(size(src,dim)), and $(size(dest,dim)) do not match"))
+    size(dest) == size(src) || throw(DimensionMismatch("Sizes $(size(dest)), $(size(src)) do not match"))
+    check_matrix(F)
+    length(b) == size(src,dim) || throw(DimensionMismatch("length(b) = $(length(b)), which does not match $(size(src,dim))"))
+    R1 = CartesianRange(size(dest)[1:dim-1])  # these are not type-stable, so let's use a function barrier
+    R2 = CartesianRange(size(dest)[dim+1:end])
+    _A_ldiv_B_md!(dest, F, src, R1, R2, b)
+end
+
+# Filtering along the first dimension
+function _A_ldiv_B_md!{T,CI<:CartesianIndex{0}}(dest, F::LU{T,Tridiagonal{T}}, src,  R1::CartesianRange{CI}, R2, b)
+    dinv = 1./F.factors.d  # might not want to do this for small R2
+    for I2 in R2
+        invert_column!(dest, F, src, I2, b, dinv)
+    end
+    dest
+end
+
+function invert_column!{T}(dest, F::LU{T,Tridiagonal{T}}, src, I2, b, dinv)
+    n = size(F, 1)
+    if n == 0
+        return nothing
+    end
+    dl = F.factors.dl
+    d  = F.factors.d
+    du = F.factors.du
+    @inbounds begin
+        # Forward substitution
+        dest[1, I2] = src[1, I2] + b[1]
+        for i = 2:n  # Can't use @simd here
+            dest[i, I2] = src[i, I2] + b[i] - dl[i-1]*dest[i-1, I2]
+        end
+        # Backward substitution
+        dest[n, I2] *= dinv[n]
+        for i = n-1:-1:1   # Can't use @simd here
+            dest[i, I2] = (dest[i, I2] - du[i]*dest[i+1, I2])*dinv[i]
+        end
+    end
+    nothing
+end
+
+# Filtering along any other dimension
+function _A_ldiv_B_md!{T}(dest, F::LU{T,Tridiagonal{T}}, src, R1, R2, b)
+    n = size(F, 1)
+    dl = F.factors.dl
+    d  = F.factors.d
+    du = F.factors.du
+    dinv = 1./d  # might not want to do this for small R1 and R2
+    # Forward substitution
+    @inbounds for I2 in R2
+        @simd for I1 in R1
+            dest[I1, 1, I2] = src[I1, 1, I2] + b[1]
+        end
+        for i = 2:n
+            @simd for I1 in R1
+                dest[I1, i, I2] = src[I1, i, I2] + b[i] - dl[i-1]*dest[I1, i-1, I2]
+            end
+        end
+        # Backward substitution
+        @simd for I1 in R1
+            dest[I1, n, I2] *= dinv[n]
+        end
+        for i = n-1:-1:1
+            @simd for I1 in R1
+                dest[I1, i, I2] = (dest[I1, i, I2] - du[i]*dest[I1, i+1, I2])*dinv[i]
+            end
+        end
+    end
+    dest
+end
+
+### Woodbury inversion along dimension 1
+# Here we support only dimension 1 because the matrix multiplications in Woodbury
+# inversion cannot be done in a cache-friendly way for any other dimension.
+# It's therefore better to permutedims.
+function filter_dim1!(dest, W::Woodbury, src, b)
+    size(src,1) == size(W,1) == length(b) || throw(DimensionMismatch("Sizes $(size(src,1)), $(size(W,1)), and $(length(b)) do not match"))
+    size(src) == size(dest) || throw(DimensionMismatch("Sizes $(size(dest)), $(size(src)) do not match"))
+    check_matrix(W.A)
+    R = CartesianRange(size(dest)[2:end])
+    _filter_dim1!(dest, W, src, b, R)
+end
+
+function _filter_dim1!(dest, W::Woodbury, src, b, R)
+    dinv = 1./W.A.factors.d
+    n = length(dinv)
+    tmp = W.tmpN2
+    dl, du = W.A.factors.dl, W.A.factors.du
+    for I in R   # iterate over "columns"
+        invert_column!(dest, W.A, src, I, b, dinv)
+        # TODO? Manually fuse the tridiagonal inversions with their "adjacent" matrix multiplications
+        A_mul_b!(W.tmpk1, W.V, dest, I)
+        A_mul_B!(W.tmpk2, W.Cp, W.tmpk1)
+        A_mul_B!(tmp, W.U, W.tmpk2)
+        # Fuses the final tridiagonal solve with the offset
+        @inbounds begin
+            # Forward substitution
+            for i = 2:n  # Can't use @simd here
+                tmp[i] = tmp[i] - dl[i-1]*tmp[i-1]
+            end
+            # Backward substitution
+            t = tmp[n]*dinv[n]
+            dest[n, I] -= t
+            for i = n-1:-1:1   # Can't use @simd here
+                t = (tmp[i] - du[i]*t)*dinv[i]
+                dest[i, I] -= t
+            end
+        end
+    end
+    dest
+end
+
+function check_matrix{T}(F::LU{T,Tridiagonal{T}})
+    for i = 1:size(F,1)
+        F.ipiv[i] == i || error("For efficiency, pivoting is not supported")
+    end
+    du2 = F.factors.du2
+    for i = 1:length(du2)
+        du2[i] == 0 || error("For efficiency, du2 must be all zeros")
+    end
+end
+
+check_matrix(M) = error("unsupported matrix type $(typeof(M))")
+
+function A_mul_b!(dest, A, B, I)
+    fill!(dest, 0)
+    for j = 1:size(A,2)
+        b = B[j,I]
+        @simd for i = 1:size(A,1)
+            dest[i] += A[i,j]*b
+        end
+    end 
+end

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -5,7 +5,7 @@ Linear{GR<:GridRepresentation}(::GR) = Linear{GR}()
 function define_indices(::Linear, N)
     quote
         @nexprs $N d->begin
-            ix_d = clamp(floor(real(x_d)), 1, size(itp,d)-1)
+            ix_d = clamp(floor(Int, real(x_d)), 1, size(itp,d)-1)
             ixp_d = ix_d + 1
             fx_d = x_d - ix_d
         end

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -85,7 +85,7 @@ function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type
     dl,d,du = inner_system_diags(T,n,q)
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
-    lufact!(Tridiagonal(dl, d, du)), zeros(TCoefs, n)
+    lufact!(Tridiagonal(dl, d, du), Val{false}), zeros(TCoefs, n)
 end
 
 function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{BC,OnGrid})
@@ -103,7 +103,7 @@ function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type
     # [1,3]         [n,n-2]
     valspec[1,1] = valspec[2,2] = 1
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
+    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
 function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Line})
@@ -121,7 +121,7 @@ function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Qua
     # [1,3]         [n,n-2]
     valspec[1,1] = valspec[2,2] = 1
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
+    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
 function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Free})
@@ -141,7 +141,7 @@ function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Qua
     # [1,4]          [n,n-3]
     valspec[2,2] = valspec[4,4] = -1
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
+    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
 function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Quadratic{Periodic})
@@ -157,5 +157,5 @@ function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, q::Qua
     # [1,n]            [n,1]
     valspec[1,1] = valspec[2,2] = 1//8
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du)), rowspec, valspec, colspec), zeros(TCoefs, n)
+    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -7,7 +7,7 @@ function define_indices(q::Quadratic, N)
     quote
         pad = padding($q)
         @nexprs $N d->begin
-            ix_d = clamp(round(real(x_d)), 1, size(itp,d)) + pad
+            ix_d = clamp(round(Int, real(x_d)), 1, size(itp,d)) + pad
             ixp_d = ix_d + 1
             ixm_d = ix_d - 1
 
@@ -19,7 +19,7 @@ function define_indices(q::Quadratic{Periodic}, N)
     quote
         pad = padding($q)
         @nexprs $N d->begin
-            ix_d = clamp(round(real(x_d)), 1, size(itp,d)) + pad
+            ix_d = clamp(round(Int, real(x_d)), 1, size(itp,d)) + pad
             ixp_d = mod1(ix_d + 1, size(itp,d))
             ixm_d = mod1(ix_d - 1, size(itp,d))
 


### PR DESCRIPTION
As perhaps you can tell, I'm making a push to replace some of my practical uses of Grid with Interpolations. I think the last remaining hangup is that I have situations in which I've pre-allocated a bunch of SharedArrays for the coefficients, and hence (if I'm going to get the multi-processing benefit of these SharedArrays) need the ability to do interpolation using in-place (destructive) processing.

This is a first stab at achieving this. The messiest part of this is passing both the full interpolation-type and the `OnCell`/`OnGrid` status to `extrap_transform_x`. I can clean that up if you otherwise think this basic idea is acceptable. (And add documentation, etc.)

To clarify one important aspect of the behavior: for `Quadratic{Interior,OnGrid}`, the interpolation can only be evaluated over the domain `[1.5+eps,size(A,d)-0.5-eps]`. I'm personally prepared to live with that, but I wanted you to be aware of this.