### PR TITLE
In-place interpolations revisited

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -2,6 +2,7 @@ module Interpolations
 
 export
     interpolate,
+    interpolate!,
     extrapolate,
 
     OnCell,

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -38,7 +38,8 @@ immutable Periodic <: BoundaryCondition end
 immutable Reflect <: BoundaryCondition end
 typealias Natural Line
 
-size(itp::AbstractInterpolation) = tuple([size(itp,i) for i in 1:ndims(itp)]...)
+# TODO: size might have to be faster?
+size{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->size(itp,i), N)::NTuple{N,Int}
 size(exp::AbstractExtrapolation, d) = size(exp.itp, d)
 gridtype{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}) = GT
 

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -36,6 +36,11 @@ interpolate{IT<:BSpline,GT<:GridType}(A::AbstractArray, ::Type{IT}, ::Type{GT}) 
 interpolate{IT<:BSpline,GT<:GridType}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate(Float32, A, IT, GT)
 interpolate{IT<:BSpline,GT<:GridType}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate(Rational{Int}, A, IT, GT)
 
+interpolate!{TWeights,IT<:BSpline,GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = BSplineInterpolation(TWeights, prefilter!(TWeights, A, IT, GT), IT, GT, Val{0}())
+interpolate!{IT<:BSpline,GT<:GridType}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate!(Float64, A, IT, GT)
+interpolate!{IT<:BSpline,GT<:GridType}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate!(Float32, A, IT, GT)
+interpolate!{IT<:BSpline,GT<:GridType}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate!(Rational{Int}, A, IT, GT)
+
 include("constant.jl")
 include("linear.jl")
 include("quadratic.jl")

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -1,6 +1,6 @@
 immutable Constant <: Degree{0} end
 
-function define_indices(::Type{BSpline{Constant}}, N)
+function define_indices(::Type{BSpline{Constant}}, N, pad)
     :(@nexprs $N d->(ix_d = clamp(round(Int, real(x_d)), 1, size(itp, d))))
 end
 

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -2,13 +2,13 @@ using Base.Cartesian
 
 import Base.getindex
 
-function getindex_impl{T,N,TCoefs,IT<:BSpline,GT<:GridType}(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT}})
+function getindex_impl{T,N,TCoefs,IT<:BSpline,GT<:GridType,Pad}(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}})
     quote
         @nexprs $N d->(x_d = xs[d])
 
         # Calculate the indices of all coefficients that will be used
         # and define fx = x - xi in each dimension
-        $(define_indices(IT, N))
+        $(define_indices(IT, N, Pad))
 
         # Calculate coefficient weights based on fx
         $(coefficients(IT, N))

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -1,6 +1,6 @@
 immutable Linear <: Degree{1} end
 
-function define_indices(::Type{BSpline{Linear}}, N)
+function define_indices(::Type{BSpline{Linear}}, N, pad)
     quote
         @nexprs $N d->begin
             ix_d = clamp(floor(Int, real(x_d)), 1, size(itp, d)-1)

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -1,6 +1,6 @@
-padding{IT<:BSpline}(::Type{IT}) = 0
+padding{IT<:BSpline}(::Type{IT}) = Val{0}()
 
-function padded_index{N}(sz::NTuple{N,Int}, pad)
+function padded_index{N,pad}(sz::NTuple{N,Int}, ::Val{pad})
     szpad = ntuple(i->sz[i]+2pad, N)::NTuple{N,Int}
     ind = Array(UnitRange{Int},N)
     for i in 1:N
@@ -9,20 +9,27 @@ function padded_index{N}(sz::NTuple{N,Int}, pad)
     ind,szpad
 end
 function copy_with_padding{IT<:InterpolationType}(A, ::Type{IT})
-    pad = padding(IT)
-    ind,sz = padded_index(size(A), pad)
+    Pad = padding(IT)
+    ind,sz = padded_index(size(A), Pad)
     coefs = zeros(eltype(A), sz...)
     coefs[ind...] = A
-    coefs, pad
+    coefs, Pad
 end
 
 prefilter!{TWeights, IT<:BSpline, GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = A
-prefilter{TWeights, IT<:BSpline, GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = prefilter!(TWeights, copy(A), IT, GT)
+prefilter{TWeights, IT<:BSpline, GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = prefilter!(TWeights, copy(A), IT, GT), Val{0}()
 
 function prefilter{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
     ::Type{TWeights}, A::Array{TCoefs,N}, ::Type{BSpline{IT}}, ::Type{GT}
     )
-    ret, pad = copy_with_padding(A, BSpline{IT})
+    ret, Pad = copy_with_padding(A, BSpline{IT})
+    prefilter!(TWeights, ret, BSpline{IT}, GT), Pad
+end
+
+function prefilter!{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
+    ::Type{TWeights}, ret::Array{TCoefs,N}, ::Type{BSpline{IT}}, ::Type{GT}
+    )
+    local buf, shape, retrs
     sz = size(ret)
     first = true
     for dim in 1:N

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -1,12 +1,12 @@
 padding{IT<:BSpline}(::Type{IT}) = 0
 
 function padded_index{N}(sz::NTuple{N,Int}, pad)
-    sz = [s+2pad for s in sz]
-    ind = Array(Any,N)
+    szpad = ntuple(i->sz[i]+2pad, N)::NTuple{N,Int}
+    ind = Array(UnitRange{Int},N)
     for i in 1:N
-        ind[i] = 1+pad:sz[i]-pad
+        ind[i] = 1+pad:szpad[i]-pad
     end
-    ind,sz
+    ind,szpad
 end
 function copy_with_padding{IT<:InterpolationType}(A, ::Type{IT})
     pad = padding(IT)
@@ -38,7 +38,7 @@ function prefilter{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
             end
             bufrs = reshape(buf, shape)
             filter_dim1!(bufrs, M, retrs, b)
-            shape = (sz[dim+1:end]..., sz[1:dim]...)
+            shape = (sz[dim+1:end]..., sz[1:dim]...)::NTuple{N,Int}
             retrs = reshape(ret, shape)
             permutedims!(retrs, bufrs, ((2:N)..., 1))
         end

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -9,51 +9,53 @@ A1 = rand(Float64, N1) * 100
 A2 = rand(Float64, N1, N1) * 100
 A3 = rand(Float64, N1, N1, N1) * 100
 
-itp1c = @inferred(interpolate(A1, BSpline(Constant), OnCell))
-itp1g = @inferred(interpolate(A1, BSpline(Constant), OnGrid))
-itp2c = @inferred(interpolate(A2, BSpline(Constant), OnCell))
-itp2g = @inferred(interpolate(A2, BSpline(Constant), OnGrid))
-itp3c = @inferred(interpolate(A3, BSpline(Constant), OnCell))
-itp3g = @inferred(interpolate(A3, BSpline(Constant), OnGrid))
+for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
+    itp1c = @inferred(constructor(copier(A1), BSpline(Constant), OnCell))
+    itp1g = @inferred(constructor(copier(A1), BSpline(Constant), OnGrid))
+    itp2c = @inferred(constructor(copier(A2), BSpline(Constant), OnCell))
+    itp2g = @inferred(constructor(copier(A2), BSpline(Constant), OnGrid))
+    itp3c = @inferred(constructor(copier(A3), BSpline(Constant), OnCell))
+    itp3g = @inferred(constructor(copier(A3), BSpline(Constant), OnGrid))
 
-# Evaluation on provided data points
-# 1D
-for i in 1:length(A1)
-    @test A1[i] == itp1c[i] == itp1g[i]
-    @test A1[i] == itp1c[convert(Float64,i)] == itp1g[convert(Float64,i)]
-end
-@test @inferred(size(itp1c)) == size(A1)
-@test @inferred(size(itp1g)) == size(A1)
-# 2D
-for i in 1:N1, j in 1:N1
-    @test A2[i,j] == itp2c[i,j] == itp2g[i,j]
-    @test A2[i,j] == itp2c[convert(Float64,i),convert(Float64,j)] == itp2g[convert(Float64,i),convert(Float64,j)]
-end
-@test @inferred(size(itp2c)) == size(A2)
-@test @inferred(size(itp2g)) == size(A2)
-# 3D
-for i in 1:N1, j in 1:N1, k in 1:N1
-    @test A3[i,j,k] == itp3c[i,j,k] == itp3g[i,j,k]
-    @test A3[i,j,k] == itp3c[convert(Float64,i),convert(Float64,j),convert(Float64,k)] == itp3g[convert(Float64,i),convert(Float64,j),convert(Float64,k)]
-end
-@test @inferred(size(itp3c)) == size(A3)
-@test @inferred(size(itp3g)) == size(A3)
+    # Evaluation on provided data points
+    # 1D
+    for i in 1:length(A1)
+        @test A1[i] == itp1c[i] == itp1g[i]
+        @test A1[i] == itp1c[convert(Float64,i)] == itp1g[convert(Float64,i)]
+    end
+    @test @inferred(size(itp1c)) == size(A1)
+    @test @inferred(size(itp1g)) == size(A1)
+    # 2D
+    for i in 1:N1, j in 1:N1
+        @test A2[i,j] == itp2c[i,j] == itp2g[i,j]
+        @test A2[i,j] == itp2c[convert(Float64,i),convert(Float64,j)] == itp2g[convert(Float64,i),convert(Float64,j)]
+    end
+    @test @inferred(size(itp2c)) == size(A2)
+    @test @inferred(size(itp2g)) == size(A2)
+    # 3D
+    for i in 1:N1, j in 1:N1, k in 1:N1
+        @test A3[i,j,k] == itp3c[i,j,k] == itp3g[i,j,k]
+        @test A3[i,j,k] == itp3c[convert(Float64,i),convert(Float64,j),convert(Float64,k)] == itp3g[convert(Float64,i),convert(Float64,j),convert(Float64,k)]
+    end
+    @test @inferred(size(itp3c)) == size(A3)
+    @test @inferred(size(itp3g)) == size(A3)
 
-# Evaluation between data points
-for i in 2:N1-1
-    @test A1[i] == itp1c[i+.3] == itp1g[i+.3] == itp1c[i-.3] == itp1g[i-.3]
-end
-# 2D
-for i in 2:N1-1, j in 2:N1-1
-    @test A2[i,j] == itp2c[i+.4,j-.3] == itp2g[i+.4,j-.3]
-end
-# 3D
-for i in 2:N1-1, j in 2:N1-1, k in 2:N1-1
-    @test A3[i,j,k] == itp3c[i+.4,j-.3,k+.1] == itp3g[i+.4,j-.3,k+.2]
-end
+    # Evaluation between data points
+    for i in 2:N1-1
+        @test A1[i] == itp1c[i+.3] == itp1g[i+.3] == itp1c[i-.3] == itp1g[i-.3]
+    end
+    # 2D
+    for i in 2:N1-1, j in 2:N1-1
+        @test A2[i,j] == itp2c[i+.4,j-.3] == itp2g[i+.4,j-.3]
+    end
+    # 3D
+    for i in 2:N1-1, j in 2:N1-1, k in 2:N1-1
+        @test A3[i,j,k] == itp3c[i+.4,j-.3,k+.1] == itp3g[i+.4,j-.3,k+.2]
+    end
 
-# Edge behavior
-@test A1[1] == itp1c[.7]
-@test A1[N1] == itp1c[N1+.3]
+    # Edge behavior
+    @test A1[1] == itp1c[.7]
+    @test A1[N1] == itp1c[N1+.3]
+end
 
 end

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -9,12 +9,12 @@ A1 = rand(Float64, N1) * 100
 A2 = rand(Float64, N1, N1) * 100
 A3 = rand(Float64, N1, N1, N1) * 100
 
-itp1c = interpolate(A1, BSpline(Constant), OnCell)
-itp1g = interpolate(A1, BSpline(Constant), OnGrid)
-itp2c = interpolate(A2, BSpline(Constant), OnCell)
-itp2g = interpolate(A2, BSpline(Constant), OnGrid)
-itp3c = interpolate(A3, BSpline(Constant), OnCell)
-itp3g = interpolate(A3, BSpline(Constant), OnGrid)
+itp1c = @inferred(interpolate(A1, BSpline(Constant), OnCell))
+itp1g = @inferred(interpolate(A1, BSpline(Constant), OnGrid))
+itp2c = @inferred(interpolate(A2, BSpline(Constant), OnCell))
+itp2g = @inferred(interpolate(A2, BSpline(Constant), OnGrid))
+itp3c = @inferred(interpolate(A3, BSpline(Constant), OnCell))
+itp3g = @inferred(interpolate(A3, BSpline(Constant), OnGrid))
 
 # Evaluation on provided data points
 # 1D

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -22,16 +22,22 @@ for i in 1:length(A1)
     @test A1[i] == itp1c[i] == itp1g[i]
     @test A1[i] == itp1c[convert(Float64,i)] == itp1g[convert(Float64,i)]
 end
+@test @inferred(size(itp1c)) == size(A1)
+@test @inferred(size(itp1g)) == size(A1)
 # 2D
 for i in 1:N1, j in 1:N1
     @test A2[i,j] == itp2c[i,j] == itp2g[i,j]
     @test A2[i,j] == itp2c[convert(Float64,i),convert(Float64,j)] == itp2g[convert(Float64,i),convert(Float64,j)]
 end
+@test @inferred(size(itp2c)) == size(A2)
+@test @inferred(size(itp2g)) == size(A2)
 # 3D
 for i in 1:N1, j in 1:N1, k in 1:N1
     @test A3[i,j,k] == itp3c[i,j,k] == itp3g[i,j,k]
     @test A3[i,j,k] == itp3c[convert(Float64,i),convert(Float64,j),convert(Float64,k)] == itp3g[convert(Float64,i),convert(Float64,j),convert(Float64,k)]
 end
+@test @inferred(size(itp3c)) == size(A3)
+@test @inferred(size(itp3g)) == size(A3)
 
 # Evaluation between data points
 for i in 2:N1-1

--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -9,32 +9,34 @@ f(x) = g1(x)
 
 A1 = Float64[f(x) for x in 1:xmax]
 
-itp1c = @inferred(interpolate(A1, BSpline(Linear), OnCell))
+for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
+    itp1c = @inferred(constructor(copier(A1), BSpline(Linear), OnCell))
 
-# Just interpolation
-for x in 1:.2:xmax
-    @test_approx_eq_eps f(x) itp1c[x] abs(.1*f(x))
-end
+    # Just interpolation
+    for x in 1:.2:xmax
+        @test_approx_eq_eps f(x) itp1c[x] abs(.1*f(x))
+    end
 
-# Rational element types
-fr(x) = (x^2) // 40 + 2
-A1R = Rational{Int}[fr(x) for x in 1:10]
-itp1r = @inferred(interpolate(A1R, BSpline(Linear), OnGrid))
-@test @inferred(size(itp1r)) == size(A1R)
-@test_approx_eq_eps itp1r[23//10] fr(23//10) abs(.1*fr(23//10))
-@test typeof(itp1r[23//10]) == Rational{Int}
-@test eltype(itp1r) == Rational{Int}
+    # Rational element types
+    fr(x) = (x^2) // 40 + 2
+    A1R = Rational{Int}[fr(x) for x in 1:10]
+    itp1r = @inferred(constructor(copier(A1R), BSpline(Linear), OnGrid))
+    @test @inferred(size(itp1r)) == size(A1R)
+    @test_approx_eq_eps itp1r[23//10] fr(23//10) abs(.1*fr(23//10))
+    @test typeof(itp1r[23//10]) == Rational{Int}
+    @test eltype(itp1r) == Rational{Int}
 
-# 2D
-g2(y) = cos(y/6)
-f(x,y) = g1(x)*g2(y)
-ymax = 10
-A2 = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
-itp2 = @inferred(interpolate(A2, BSpline(Linear), OnGrid))
-@test @inferred(size(itp2)) == size(A2)
+    # 2D
+    g2(y) = cos(y/6)
+    f(x,y) = g1(x)*g2(y)
+    ymax = 10
+    A2 = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
+    itp2 = @inferred(constructor(copier(A2), BSpline(Linear), OnGrid))
+    @test @inferred(size(itp2)) == size(A2)
 
-for x in 2.1:.2:xmax-1, y in 1.9:.2:ymax-.9
-    @test_approx_eq_eps f(x,y) itp2[x,y] abs(.25*f(x,y))
+    for x in 2.1:.2:xmax-1, y in 1.9:.2:ymax-.9
+        @test_approx_eq_eps f(x,y) itp2[x,y] abs(.25*f(x,y))
+    end
 end
 
 end

--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -9,7 +9,7 @@ f(x) = g1(x)
 
 A1 = Float64[f(x) for x in 1:xmax]
 
-itp1c = interpolate(A1, BSpline(Linear), OnCell)
+itp1c = @inferred(interpolate(A1, BSpline(Linear), OnCell))
 
 # Just interpolation
 for x in 1:.2:xmax
@@ -19,7 +19,7 @@ end
 # Rational element types
 fr(x) = (x^2) // 40 + 2
 A1R = Rational{Int}[fr(x) for x in 1:10]
-itp1r = interpolate(A1R, BSpline(Linear), OnGrid)
+itp1r = @inferred(interpolate(A1R, BSpline(Linear), OnGrid))
 @test_approx_eq_eps itp1r[23//10] fr(23//10) abs(.1*fr(23//10))
 @test typeof(itp1r[23//10]) == Rational{Int}
 @test eltype(itp1r) == Rational{Int}
@@ -29,7 +29,7 @@ g2(y) = cos(y/6)
 f(x,y) = g1(x)*g2(y)
 ymax = 10
 A2 = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
-itp2 = interpolate(A2, BSpline(Linear), OnGrid)
+itp2 = @inferred(interpolate(A2, BSpline(Linear), OnGrid))
 
 for x in 2.1:.2:xmax-1, y in 1.9:.2:ymax-.9
     @test_approx_eq_eps f(x,y) itp2[x,y] abs(.25*f(x,y))

--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -20,6 +20,7 @@ end
 fr(x) = (x^2) // 40 + 2
 A1R = Rational{Int}[fr(x) for x in 1:10]
 itp1r = @inferred(interpolate(A1R, BSpline(Linear), OnGrid))
+@test @inferred(size(itp1r)) == size(A1R)
 @test_approx_eq_eps itp1r[23//10] fr(23//10) abs(.1*fr(23//10))
 @test typeof(itp1r[23//10]) == Rational{Int}
 @test eltype(itp1r) == Rational{Int}
@@ -30,6 +31,7 @@ f(x,y) = g1(x)*g2(y)
 ymax = 10
 A2 = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
 itp2 = @inferred(interpolate(A2, BSpline(Linear), OnGrid))
+@test @inferred(size(itp2)) == size(A2)
 
 for x in 2.1:.2:xmax-1, y in 1.9:.2:ymax-.9
     @test_approx_eq_eps f(x,y) itp2[x,y] abs(.25*f(x,y))

--- a/test/b-splines/quadratic.jl
+++ b/test/b-splines/quadratic.jl
@@ -2,48 +2,48 @@ module Quadratic1DTests
 
 using Interpolations, Base.Test
 
-f(x) = sin((x-3)*2pi/9 - 1)
-xmax = 10
+for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
+    f(x) = sin((x-3)*2pi/9 - 1)
+    xmax = 10
+    A = Float64[f(x) for x in 1:xmax]
+    for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
+        itp1 = @inferred(constructor(copier(A), BSpline(Quadratic(BC)), GT))
+        @test @inferred(size(itp1)) == size(A)
 
-A = Float64[f(x) for x in 1:xmax]
+        # test that inner region is close to data
+        for x in 3.1:.2:8.1
+            @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
+        end
 
-for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
-    itp1 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
-    @test @inferred(size(itp1)) == size(A)
+        # test that we can evaluate close to, and at, boundaries
+        if GT == OnGrid
+            itp1[1.]
+            itp1[1.0]
+            itp1[1.2]
+            itp1[9.8]
+            itp1[10.]
+            itp1[10]
+        else
+            itp1[0.5]
+            itp1[0.6]
+            itp1[10.4]
+            itp1[10.5]
+        end
+    end
+
+
+    f(x,y) = sin(x/10)*cos(y/6)
+    xmax, ymax = 30,10
+    A = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
 
     # test that inner region is close to data
-    for x in 3.1:.2:8.3
-        @test_approx_eq_eps f(x) itp1[x] abs(.1*f(x))
-    end
+    for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
+        itp2 = @inferred(constructor(copier(A), BSpline(Quadratic(BC)), GT))
+        @test @inferred(size(itp2)) == size(A)
 
-    # test that we can evaluate close to, and at, boundaries
-    if GT == OnGrid
-        itp1[1.]
-        itp1[1.0]
-        itp1[1.2]
-        itp1[9.8]
-        itp1[10.]
-        itp1[10]
-    else
-        itp1[0.5]
-        itp1[0.6]
-        itp1[10.4]
-        itp1[10.5]
-    end
-end
-
-
-f(x,y) = sin(x/10)*cos(y/6)
-xmax, ymax = 30,10
-A = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
-
-# test that inner region is close to data
-for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
-    itp2 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
-    @test @inferred(size(itp2)) == size(A)
-
-    for x in 3.1:.2:xmax-3, y in 3.1:2:ymax-3
-        @test_approx_eq_eps f(x,y) itp2[x,y] abs(.1*f(x,y))
+        for x in 3.1:.2:xmax-3, y in 3.1:2:ymax-3
+            @test_approx_eq_eps f(x,y) itp2[x,y] abs(.1*f(x,y))
+        end
     end
 end
 

--- a/test/b-splines/quadratic.jl
+++ b/test/b-splines/quadratic.jl
@@ -9,6 +9,7 @@ A = Float64[f(x) for x in 1:xmax]
 
 for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
     itp1 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
+    @test @inferred(size(itp1)) == size(A)
 
     # test that inner region is close to data
     for x in 3.1:.2:8.3
@@ -39,6 +40,7 @@ A = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
 # test that inner region is close to data
 for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
     itp2 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
+    @test @inferred(size(itp2)) == size(A)
 
     for x in 3.1:.2:xmax-3, y in 3.1:2:ymax-3
         @test_approx_eq_eps f(x,y) itp2[x,y] abs(.1*f(x,y))

--- a/test/b-splines/quadratic.jl
+++ b/test/b-splines/quadratic.jl
@@ -8,7 +8,7 @@ xmax = 10
 A = Float64[f(x) for x in 1:xmax]
 
 for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
-    itp1 = interpolate(A, BSpline(Quadratic(BC)), GT)
+    itp1 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
 
     # test that inner region is close to data
     for x in 3.1:.2:8.3
@@ -38,7 +38,7 @@ A = Float64[f(x,y) for x in 1:xmax, y in 1:ymax]
 
 # test that inner region is close to data
 for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
-    itp2 = interpolate(A, BSpline(Quadratic(BC)), GT)
+    itp2 = @inferred(interpolate(A, BSpline(Quadratic(BC)), GT))
 
     for x in 3.1:.2:xmax-3, y in 3.1:2:ymax-3
         @test_approx_eq_eps f(x,y) itp2[x,y] abs(.1*f(x,y))


### PR DESCRIPTION
By comparison with #34, this is probably a better approach: rather than defining a new boundary condition `Interior` and then making the indexing rules treat padding differently for this condition, this PR adds a `pad` parameter to `BSplineInterpolation`: for instance, `pad=0` for anything other than `Quadratic`, for which it is typically 1 unless (1) using `Reflect` or (2) using `interpolate!`. The code generation uses this parameter to compute appropriate index offsets.

The first commit in this PR also improves the type-stability (and adds tests for it) of several key functions. Also, I think the `size` function was broken (it included the consequences of padding, which I assume is _not_ what you wanted?); this is fixed in the 2nd commit by exploiting the new `pad` parameter.
