### PR TITLE
Faster prefiltering for the Woodbury case

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4-
 
-WoodburyMatrices
+WoodburyMatrices 0.1
 Ratios
+AxisAlgorithms

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -19,7 +19,7 @@ export
     # b-splines/b-splines.jl
     # extrapolation/extrapolation.jl
 
-using WoodburyMatrices, Ratios
+using WoodburyMatrices, Ratios, AxisAlgorithms
 
 import Base: convert, size, getindex, promote_rule
 

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -34,21 +34,7 @@ function prefilter!{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
     first = true
     for dim in 1:N
         M, b = prefiltering_system(TWeights, TCoefs, sz[dim], IT, GT)
-        if !isa(M, Woodbury)
-            A_ldiv_B_md!(ret, M, ret, dim, b)
-        else
-            if first
-                buf = Array(eltype(ret), length(ret,))
-                shape = sz
-                retrs = reshape(ret, shape)  # for type-stability against a future julia #10507
-                first = false
-            end
-            bufrs = reshape(buf, shape)
-            filter_dim1!(bufrs, M, retrs, b)
-            shape = (sz[dim+1:end]..., sz[1:dim]...)::NTuple{N,Int}
-            retrs = reshape(ret, shape)
-            permutedims!(retrs, bufrs, ((2:N)..., 1))
-        end
+        A_ldiv_B_md!(ret, M, ret, dim, b)
     end
     ret
 end

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -85,10 +85,10 @@ function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type
     d[1] = d[end] = -1
     du[1] = dl[end] = 0
 
-    rowspec = zeros(T,n,2)
+    rowspec = spzeros(T,n,2)
     # first row     last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(T,2,n)
+    colspec = spzeros(T,2,n)
     # third col     third-to-last col
     colspec[1,3] = colspec[2,n-2] = 1
     valspec = zeros(T,2,2)
@@ -103,10 +103,10 @@ function prefiltering_system{T,TCoefs,GT<:GridType}(::Type{T}, ::Type{TCoefs}, n
     d[1] = d[end] = 1
     du[1] = dl[end] = -2
 
-    rowspec = zeros(T,n,2)
+    rowspec = spzeros(T,n,2)
     # first row     last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(T,2,n)
+    colspec = spzeros(T,2,n)
     # third col     third-to-last col
     colspec[1,3] = colspec[2,n-2] = 1
     valspec = zeros(T,2,2)
@@ -121,10 +121,10 @@ function prefiltering_system{T,TCoefs,GT<:GridType}(::Type{T}, ::Type{TCoefs}, n
     d[1] = d[end] = 1
     du[1] = dl[end] = -3
 
-    rowspec = zeros(T,n,4)
+    rowspec = spzeros(T,n,4)
     # first row     first row       last row       last row
     rowspec[1,1] = rowspec[1,2] = rowspec[n,3] = rowspec[n,4] = 1
-    colspec = zeros(T,4,n)
+    colspec = spzeros(T,4,n)
     # third col     fourth col     third-to-last col  fourth-to-last col
     colspec[1,3] = colspec[2,4] = colspec[3,n-2] = colspec[4,n-3] = 1
     valspec = zeros(T,4,4)
@@ -139,10 +139,10 @@ end
 function prefiltering_system{T,TCoefs,GT<:GridType}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{Periodic}}, ::Type{GT})
     dl,d,du = inner_system_diags(T,n,Quadratic{Periodic})
 
-    rowspec = zeros(T,n,2)
+    rowspec = spzeros(T,n,2)
     # first row       last row
     rowspec[1,1] = rowspec[n,2] = 1
-    colspec = zeros(T,2,n)
+    colspec = spzeros(T,2,n)
     # last col         first col
     colspec[1,n] = colspec[2,1] = 1
     valspec = zeros(T,2,2)

--- a/src/filter1d.jl
+++ b/src/filter1d.jl
@@ -78,8 +78,8 @@ function _A_ldiv_B_md!(dest, W::Woodbury, src,  R1, R2, b)
     tmp2 = AxisAlgorithms._A_mul_B_md(W.Cp, tmp1, R1, R2)
     tmp3 = AxisAlgorithms._A_mul_B_md(W.U, tmp2, R1, R2)
     # TODO?: would be nice to fuse the next two steps
-    tmp4 = AxisAlgorithms._A_ldiv_B_md(W.A, tmp3, R1, R2)
-    AxisAlgorithms.sub!(dest, tmp4)
+    AxisAlgorithms._A_ldiv_B_md!(tmp3, W.A, tmp3, R1, R2)
+    AxisAlgorithms.sub!(dest, tmp3)
 end
 
 function check_matrix{T}(F::LU{T,Tridiagonal{T}})

--- a/src/filter1d.jl
+++ b/src/filter1d.jl
@@ -1,8 +1,9 @@
 import Base.LinAlg.LU, Base.getindex
+import AxisAlgorithms: A_ldiv_B_md!, _A_ldiv_B_md!
 
 ### Tridiagonal inversion along a particular dimension, first offsetting the values by b
 
-function A_ldiv_B_md!{T}(dest, F::LU{T,Tridiagonal{T}}, src, dim::Integer, b::AbstractVector)
+function A_ldiv_B_md!(dest, F, src, dim::Integer, b::AbstractVector)
     1 <= dim <= max(ndims(dest),ndims(src)) || throw(DimensionMismatch("The chosen dimension $dim is larger than $(ndims(src)) and $(ndims(dest))"))
     n = size(F, 1)
     n == size(src, dim) && n == size(dest, dim) || throw(DimensionMismatch("Sizes $n, $(size(src,dim)), and $(size(dest,dim)) do not match"))
@@ -16,14 +17,6 @@ end
 
 # Filtering along the first dimension
 function _A_ldiv_B_md!{T,CI<:CartesianIndex{0}}(dest, F::LU{T,Tridiagonal{T}}, src,  R1::CartesianRange{CI}, R2, b)
-    dinv = 1./F.factors.d  # might not want to do this for small R2
-    for I2 in R2
-        invert_column!(dest, F, src, I2, b, dinv)
-    end
-    dest
-end
-
-function invert_column!{T}(dest, F::LU{T,Tridiagonal{T}}, src, I2, b, dinv)
     n = size(F, 1)
     if n == 0
         return nothing
@@ -31,7 +24,8 @@ function invert_column!{T}(dest, F::LU{T,Tridiagonal{T}}, src, I2, b, dinv)
     dl = F.factors.dl
     d  = F.factors.d
     du = F.factors.du
-    @inbounds begin
+    dinv = 1./F.factors.d  # might not want to do this for small R2
+    @inbounds for I2 in R2
         # Forward substitution
         dest[1, I2] = src[1, I2] + b[1]
         for i = 2:n  # Can't use @simd here
@@ -76,45 +70,16 @@ function _A_ldiv_B_md!{T}(dest, F::LU{T,Tridiagonal{T}}, src, R1, R2, b)
     dest
 end
 
-### Woodbury inversion along dimension 1
-# Here we support only dimension 1 because the matrix multiplications in Woodbury
-# inversion cannot be done in a cache-friendly way for any other dimension.
-# It's therefore better to permutedims.
-function filter_dim1!(dest, W::Woodbury, src, b)
-    size(src,1) == size(W,1) == length(b) || throw(DimensionMismatch("Sizes $(size(src,1)), $(size(W,1)), and $(length(b)) do not match"))
-    size(src) == size(dest) || throw(DimensionMismatch("Sizes $(size(dest)), $(size(src)) do not match"))
-    check_matrix(W.A)
-    R = CartesianRange(size(dest)[2:end])
-    _filter_dim1!(dest, W, src, b, R)
-end
+### Woodbury solver with offset
 
-function _filter_dim1!(dest, W::Woodbury, src, b, R)
-    dinv = 1./W.A.factors.d
-    n = length(dinv)
-    tmp = W.tmpN2
-    dl, du = W.A.factors.dl, W.A.factors.du
-    for I in R   # iterate over "columns"
-        invert_column!(dest, W.A, src, I, b, dinv)
-        # TODO? Manually fuse the tridiagonal inversions with their "adjacent" matrix multiplications
-        A_mul_b!(W.tmpk1, W.V, dest, I)
-        A_mul_B!(W.tmpk2, W.Cp, W.tmpk1)
-        A_mul_B!(tmp, W.U, W.tmpk2)
-        # Fuses the final tridiagonal solve with the offset
-        @inbounds begin
-            # Forward substitution
-            for i = 2:n  # Can't use @simd here
-                tmp[i] = tmp[i] - dl[i-1]*tmp[i-1]
-            end
-            # Backward substitution
-            t = tmp[n]*dinv[n]
-            dest[n, I] -= t
-            for i = n-1:-1:1   # Can't use @simd here
-                t = (tmp[i] - du[i]*t)*dinv[i]
-                dest[i, I] -= t
-            end
-        end
-    end
-    dest
+function _A_ldiv_B_md!(dest, W::Woodbury, src,  R1, R2, b)
+    _A_ldiv_B_md!(dest, W.A, src, R1, R2, b)
+    tmp1 = AxisAlgorithms._A_mul_B_md(W.V, dest, R1, R2)
+    tmp2 = AxisAlgorithms._A_mul_B_md(W.Cp, tmp1, R1, R2)
+    tmp3 = AxisAlgorithms._A_mul_B_md(W.U, tmp2, R1, R2)
+    # TODO?: would be nice to fuse the next two steps
+    tmp4 = AxisAlgorithms._A_ldiv_B_md(W.A, tmp3, R1, R2)
+    AxisAlgorithms.sub!(dest, tmp4)
 end
 
 function check_matrix{T}(F::LU{T,Tridiagonal{T}})
@@ -127,14 +92,6 @@ function check_matrix{T}(F::LU{T,Tridiagonal{T}})
     end
 end
 
-check_matrix(M) = error("unsupported matrix type $(typeof(M))")
+check_matrix(F::Woodbury) = check_matrix(F.A)
 
-function A_mul_b!(dest, A, B, I)
-    fill!(dest, 0)
-    for j = 1:size(A,2)
-        b = B[j,I]
-        @simd for i = 1:size(A,1)
-            dest[i] += A[i,j]*b
-        end
-    end 
-end
+check_matrix(M) = error("unsupported matrix type $(typeof(M))")


### PR DESCRIPTION
This gives an approximate further 2x speed improvement for prefiltering with Woodbury matrices:
```jl
Master:
julia> using Interpolations

julia> A = rand(300,300,30);

julia> Ai = copy(A);

# Delete warmup

julia> @time itp = interpolate!(Ai, BSpline(Quadratic(Periodic)), OnCell);
 465.640 milliseconds (1728 k allocations: 48201 KB, 2.23% gc time)
```
```jl
This branch:
julia> @time itp = interpolate!(Ai, BSpline(Quadratic(Periodic)), OnCell);
 234.042 milliseconds (401 allocations: 127 MB, 5.24% gc time)
```

This uses the new AxisAlgorithms package, and converts the U, V matrices to sparse format (which required updates to WoodburyMatrices.jl).

For comparison:
```jl
julia> @time yi = InterpGrid(Ai, BCperiodic, InterpQuadratic);
 648.083 milliseconds (2700 k allocations: 66754 KB, 10.09% gc time)
```
using Grid.