### PR TITLE
RFC: Scaling of interpolation objects (fixes #25)

### DIFF
--- a/perf/run_shootout.jl
+++ b/perf/run_shootout.jl
@@ -16,7 +16,7 @@ make_knots(A) = ntuple(d->collect(linspace(1,size(A,d),size(A,d))), ndims(A))
 make_xi(A)    = ntuple(d->collect(linspace(2,size(A,d)-1,size(A,d)-2)), ndims(A))
 
 ## Interpolations and Grid
-function evaluate_grid(itp::Union(Array,Interpolations.AbstractInterpolation,Grid.InterpGrid), A)
+function evaluate_grid(itp::Union{Array,Interpolations.AbstractInterpolation,Grid.InterpGrid), A}
     s = zero(eltype(itp)) + zero(eltype(itp))
     for I in iterrange(itp)
         s += itp[I]
@@ -58,7 +58,7 @@ function evaluate_grid(itp::Dierckx.Spline2D, A)
 end
 
 # Slow approach for Dierckx
-function evaluate_grid_scalar(itp::Union(Dierckx.Spline1D,Dierckx.Spline2D), A)
+function evaluate_grid_scalar(itp::Union{Dierckx.Spline1D,Dierckx.Spline2D), A}
     T = eltype(A)
     s = zero(T) + zero(T)
     for I in iterrange(A)

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -8,6 +8,9 @@ export
 
     gradient!,
 
+    AbstractInterpolation,
+    AbstractExtrapolation,
+
     OnCell,
     OnGrid,
 

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -33,7 +33,7 @@ abstract GridType
 immutable OnGrid <: GridType end
 immutable OnCell <: GridType end
 
-typealias DimSpec{T} Union(T,Tuple{Vararg{Union(T,NoInterp)}},NoInterp)
+typealias DimSpec{T} Union{T,Tuple{Vararg{Union{T,NoInterp}}},NoInterp}
 
 abstract AbstractInterpolation{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}} <: AbstractArray{T,N}
 abstract AbstractExtrapolation{T,N,ITPT,IT,GT} <: AbstractInterpolation{T,N,IT,GT}

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -36,6 +36,11 @@ iextract(t, d) = t.parameters[d]
 padextract(pad::Integer, d) = pad
 padextract(pad::Tuple{Vararg{Integer}}, d) = pad[d]
 
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d) = one(T)
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d) = convert(T, size(itp, d))
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d) = convert(T, .5)
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d) = convert(T, size(itp, d) + .5)
+
 @generated function size{T,N,TCoefs,IT,GT,pad}(itp::BSplineInterpolation{T,N,TCoefs,IT,GT,pad}, d)
     quote
         d <= $N ? size(itp.coefs, d) - 2*padextract($pad, d) : 1

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -44,7 +44,7 @@ function gradient_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
     gradient_exprs = Expr(:block, exs...)
     quote
         $meta
-        length(g) == $n || throw(DimensionMismatch("Gradient has wrong number of components"))
+        length(g) == $n || throw(ArgumentError(string("The length of the provided gradient vector (", length(g), ") did not match the number of interpolating dimensions (", n, ")")))
         @nexprs $N d->(x_d = xs[d])
 
         # Calculate the indices of all coefficients that will be used

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -39,7 +39,7 @@ function prefilter{TWeights,TCoefs,TSrc,N,IT<:Quadratic,GT<:GridType}(
     prefilter!(TWeights, ret, BSpline{IT}, GT), Pad
 end
 
-function prefilter{TWeights,TCoefs,TSrc,N,IT<:Tuple{Vararg{Union(BSpline,NoInterp)}},GT<:DimSpec{GridType}}(
+function prefilter{TWeights,TCoefs,TSrc,N,IT<:Tuple{Vararg{Union{BSpline,NoInterp}}},GT<:DimSpec{GridType}}(
     ::Type{TWeights}, ::Type{TCoefs}, A::Array{TSrc,N}, ::Type{IT}, ::Type{GT}
     )
     ret, Pad = copy_with_padding(TCoefs,A, IT)
@@ -59,7 +59,7 @@ function prefilter!{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
     ret
 end
 
-function prefilter!{TWeights,TCoefs,N,IT<:Tuple{Vararg{Union(BSpline,NoInterp)}},GT<:DimSpec{GridType}}(
+function prefilter!{TWeights,TCoefs,N,IT<:Tuple{Vararg{Union{BSpline,NoInterp}}},GT<:DimSpec{GridType}}(
     ::Type{TWeights}, ret::Array{TCoefs,N}, ::Type{IT}, ::Type{GT}
     )
     local buf, shape, retrs

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -24,7 +24,7 @@ function define_indices_d(::Type{BSpline{Quadratic{Periodic}}}, d, pad)
         $symixm = mod1($symix - 1, size(itp,$d))
     end
 end
-function define_indices_d{BC<:Union(InPlace,InPlaceQ)}(::Type{BSpline{Quadratic{BC}}}, d, pad)
+function define_indices_d{BC<:Union{InPlace,InPlaceQ}}(::Type{BSpline{Quadratic{BC}}}, d, pad)
     symix, symixm, symixp = symbol("ix_",d), symbol("ixm_",d), symbol("ixp_",d)
     symx, symfx = symbol("x_",d), symbol("fx_",d)
     pad == 0 || error("Use $BC only with interpolate!")
@@ -83,7 +83,7 @@ function inner_system_diags{T,Q<:Quadratic}(::Type{T}, n::Int, ::Type{Q})
     (dl,d,du)
 end
 
-function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnCell})
+function prefiltering_system{T,TCoefs,BC<:Union{Flat,Reflect}}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnCell})
     dl,d,du = inner_system_diags(T,n,Quadratic{BC})
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
@@ -111,7 +111,7 @@ function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type
     Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnGrid})
+function prefiltering_system{T,TCoefs,BC<:Union{Flat,Reflect}}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnGrid})
     dl,d,du = inner_system_diags(T,n,Quadratic{BC})
     d[1] = d[end] = -1
     du[1] = dl[end] = 0

--- a/src/extrapolation/constant.jl
+++ b/src/extrapolation/constant.jl
@@ -7,15 +7,12 @@ ConstantExtrapolation{T,ITP,IT,GT}(::Type{T}, N, itp::ITP, ::Type{IT}, ::Type{GT
 extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ::Type{Flat}) =
     ConstantExtrapolation(T,N,itp,IT,GT)
 
-function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnGrid}}, x)
-    :(x = clamp(x, 1, size(exp,1)))
+function extrap_prep{T,ITP,IT,GT}(etp::Type{ConstantExtrapolation{T,1,ITP,IT,GT}}, x)
+    :(x = clamp(x, lbound(etp,1), ubound(etp,1)))
 end
-function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnCell}}, x)
-    :(x = clamp(x, .5, size(exp,1)+.5))
+function extrap_prep{T,N,ITP,IT,GT}(etp::Type{ConstantExtrapolation{T,N,ITP,IT,GT}}, xs...)
+    :(@nexprs $N d->(xs[d] = clamp(xs[d], lbound(etp,d), ubound(etp,d))))
 end
-function extrap_prep{T,N,ITP,IT}(exp::Type{ConstantExtrapolation{T,N,ITP,IT,OnGrid}}, xs...)
-    :(@nexprs $N d->(xs[d] = clamp(xs[d], 1, size(exp,d))))
-end
-function extrap_prep{T,N,ITP,IT}(exp::Type{ConstantExtrapolation{T,N,ITP,IT,OnCell}}, xs...)
-    :(@nexprs $N d->(xs[d] = clamp(xs[d], .5, size(exp,d)+.5)))
-end
+
+lbound(etp::ConstantExtrapolation, d) = lbound(etp.itp, d)
+ubound(etp::ConstantExtrapolation, d) = ubound(etp.itp, d)

--- a/src/extrapolation/error.jl
+++ b/src/extrapolation/error.jl
@@ -7,7 +7,9 @@ ErrorExtrapolation{T,ITPT,IT,GT}(::Type{T}, N, itp::ITPT, ::Type{IT}, ::Type{GT}
 extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ::Type{Throw}) = 
     ErrorExtrapolation(T,N,itp,IT,GT)
 
-
-function extrap_prep{T,N,ITPT,IT}(exp::Type{ErrorExtrapolation{T,N,ITPT,IT,OnGrid}}, xs...)
-    :(@nexprs $N d->(@show 1 <= xs[d] <= size(exp,d) || throw(BoundsError())))
+function extrap_prep{T,N,ITPT,IT,GT}(etp::Type{ErrorExtrapolation{T,N,ITPT,IT,GT}}, xs...)
+    :(@nexprs $N d->(lbound(etp,d) <= xs[d] <= ubound(etp,d) || throw(BoundsError())))
 end
+
+lbound(etp::ErrorExtrapolation, d) = lbound(etp.itp, d)
+ubound(etp::ErrorExtrapolation, d) = ubound(etp.itp, d)

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -1,5 +1,5 @@
 export Throw,
-       FilledInterpolation   # for direct control over typeof(fillvalue)
+       FilledExtrapolation   # for direct control over typeof(fillvalue)
 
 include("error.jl")
 

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -1,25 +1,25 @@
 nindexes(N::Int) = N == 1 ? "1 index" : "$N indexes"
 
 
-type FilledInterpolation{T,N,ITP<:AbstractInterpolation,IT,GT,FT} <: AbstractExtrapolation{T,N,ITP,IT,GT}
+type FilledExtrapolation{T,N,ITP<:AbstractInterpolation,IT,GT,FT} <: AbstractExtrapolation{T,N,ITP,IT,GT}
     itp::ITP
     fillvalue::FT
 end
 @doc """
-`FilledInterpolation(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
+`FilledExtrapolation(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
 
 By comparison with `extrapolate`, this version lets you control the `fillvalue`'s type directly.  It's important for the `fillvalue` to be of the same type as returned by `itp[x1,x2,...]` for in-bounds regions for the index types you are using; otherwise, indexing will be type-unstable (and slow).
 """ ->
-function FilledInterpolation{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue)
-    FilledInterpolation{T,N,typeof(itp),IT,GT,typeof(fillvalue)}(itp, fillvalue)
+function FilledExtrapolation{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue)
+    FilledExtrapolation{T,N,typeof(itp),IT,GT,typeof(fillvalue)}(itp, fillvalue)
 end
 
 @doc """
 `extrapolate(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
 """ ->
-extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = FilledInterpolation(itp, convert(eltype(itp), fillvalue))
+extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = FilledExtrapolation(itp, convert(eltype(itp), fillvalue))
 
-@generated function getindex{T,N}(fitp::FilledInterpolation{T,N}, args::Number...)
+@generated function getindex{T,N}(fitp::FilledExtrapolation{T,N}, args::Number...)
     n = length(args)
     n == N || return error("Must index $(N)-dimensional interpolation objects with $(nindexes(N))")
     meta = Expr(:meta, :inline)
@@ -33,4 +33,4 @@ extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = Fille
     end
 end
 
-getindex{T}(fitp::FilledInterpolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x] : throw(BoundsError())
+getindex{T}(fitp::FilledExtrapolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x] : throw(BoundsError())

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -5,18 +5,18 @@ type FilledExtrapolation{T,N,ITP<:AbstractInterpolation,IT,GT,FT} <: AbstractExt
     itp::ITP
     fillvalue::FT
 end
-@doc """
+"""
 `FilledExtrapolation(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
 
 By comparison with `extrapolate`, this version lets you control the `fillvalue`'s type directly.  It's important for the `fillvalue` to be of the same type as returned by `itp[x1,x2,...]` for in-bounds regions for the index types you are using; otherwise, indexing will be type-unstable (and slow).
-""" ->
+"""
 function FilledExtrapolation{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue)
     FilledExtrapolation{T,N,typeof(itp),IT,GT,typeof(fillvalue)}(itp, fillvalue)
 end
 
-@doc """
+"""
 `extrapolate(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
-""" ->
+"""
 extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = FilledExtrapolation(itp, convert(eltype(itp), fillvalue))
 
 @generated function getindex{T,N}(fitp::FilledExtrapolation{T,N}, args::Number...)

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -27,10 +27,13 @@ extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = Fille
         $meta
         # Check to see if we're in the extrapolation region, i.e.,
         # out-of-bounds in an index
-        @nexprs $N d->((args[d] < 1 || args[d] > size(fitp.itp, d)) && return fitp.fillvalue)
+        @nexprs $N d->((args[d] < lbound(fitp,d) || args[d] > ubound(fitp, d)) && return fitp.fillvalue)
         # In the interpolation region
         return getindex(fitp.itp,args...)
     end
 end
 
 getindex{T}(fitp::FilledExtrapolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x] : throw(BoundsError())
+
+lbound(etp::FilledExtrapolation, d) = lbound(etp.itp, d)
+ubound(etp::FilledExtrapolation, d) = ubound(etp.itp, d)

--- a/src/extrapolation/indexing.jl
+++ b/src/extrapolation/indexing.jl
@@ -1,13 +1,13 @@
-@generated function getindex{T}(exp::AbstractExtrapolation{T,1}, x)
+@generated function getindex{T}(etp::AbstractExtrapolation{T,1}, x)
     quote
-        $(extrap_prep(exp, x))
-        exp.itp[x]
+        $(extrap_prep(etp, x))
+        etp.itp[x]
     end
 end
 
-@generated function getindex{T,N,ITP,GT}(exp::AbstractExtrapolation{T,N,ITP,GT}, xs...)
+@generated function getindex{T,N,ITP,GT}(etp::AbstractExtrapolation{T,N,ITP,GT}, xs...)
     quote
-        $(extrap_prep(exp, xs...))
-        exp.itp[xs...]
+        $(extrap_prep(etp, xs...))
+        etp.itp[xs...]
     end
 end

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -5,7 +5,7 @@ Gridded{D<:Degree}(::Type{D}) = Gridded{D}
 
 griddedtype{D<:Degree}(::Type{Gridded{D}}) = D
 
-typealias GridIndex{T} Union(AbstractVector{T}, Tuple)
+typealias GridIndex{T} Union{AbstractVector{T}, Tuple}
 
 # Because Ranges check bounds on getindex, it's actually faster to convert the
 # knots to Vectors. It's also good to take a copy, so it doesn't get modified later.

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -1,0 +1,69 @@
+type ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
+    itp::ITPT
+    ranges::RT
+end
+ScaledInterpolation{T,ITPT,IT,GT,RT}(::Type{T}, N, itp::ITPT, ::Type{IT}, ::Type{GT}, ranges::RT) =
+    ScaledInterpolation{T,N,ITPT,IT,GT,RT}(itp, ranges)
+function scale{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ranges::Range...)
+    length(ranges) == N || throw(ArgumentError("Must scale $N-dimensional interpolation object with exactly $N ranges (you used $(length(ranges)))"))
+    for d in 1:N
+        if iextract(IT,d) != NoInterp 
+            length(ranges[d]) == size(itp,d) || throw(ArgumentError("The length of the range in dimension $d ($(length(ranges[d]))) did not equal the size of the interpolation object in that direction ($(size(itp,d)))"))
+        elseif ranges[d] != 1:size(itp,d)
+            throw(ArgumentError("NoInterp dimension $d must be scaled with unit range 1:$(size(itp,d))"))
+        end
+    end
+
+    ScaledInterpolation(T,N,itp,IT,GT,ranges)
+end
+
+@generated function getindex{T,N,ITPT,IT<:DimSpec}(sitp::ScaledInterpolation{T,N,ITPT,IT}, xs...)
+    length(xs) == N || throw(ArgumentError("Must index into $N-dimensional scaled interpolation object with exactly $N indices (you used $(length(xs)))"))
+    interp_types = length(IT.parameters) == N ? IT.parameters : tuple([IT.parameters[1] for _ in 1:N]...)
+    interp_dimens = map(it -> interp_types[it] != NoInterp, 1:N)
+    interp_indices = map(i -> interp_dimens[i] ? :(coordlookup(sitp.ranges[$i], xs[$i])) : :(xs[$i]), 1:N)
+    return :(getindex(sitp.itp, $(interp_indices...)))
+end
+
+getindex{T}(sitp::ScaledInterpolation{T,1}, x::Number, y::Int) = y == 1 ? sitp[x] : throw(BoundsError())
+
+size(sitp::ScaledInterpolation, d) = size(sitp.itp, d)
+lbound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnGrid}, d) = 1 <= d <= N ? sitp.ranges[d][1] : throw(BoundsError())
+lbound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d) = 1 <= d <= N ? sitp.ranges[d][1] - boundstep(sitp.ranges[d]) : throw(BoundsError())
+ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnGrid}, d) = 1 <= d <= N ? sitp.ranges[d][end] : throw(BoundsError())
+ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d) = 1 <= d <= N ? sitp.ranges[d][end] + boundstep(sitp.ranges[d]) : throw(BoundsError())
+
+boundstep(r::LinSpace) = ((r.stop - r.start) / r.divisor) / 2
+boundstep(r::FloatRange) = r.step / 2
+boundstep(r::StepRange) = r.step / 2
+boundstep(r::UnitRange) = 1//2
+
+coordlookup(r::LinSpace, x) = (r.divisor * x + r.stop - r.len * r.start) / (r.stop - r.start)
+coordlookup(r::FloatRange, x) = (r.divisor * x - r.start) / r.step + one(eltype(r))
+coordlookup(r::StepRange, x) = (x - r.start) / r.step + one(eltype(r))
+coordlookup(r::UnitRange, x) = x - r.start + one(eltype(r))
+coordlookup(i::Bool, r::Range, x) = i ? coordlookup(r, x) : convert(typeof(coordlookup(r,x)), x)
+
+gradient{T,N}(sitp::ScaledInterpolation{T,N}, xs...) = gradient!(Array(T,N), sitp, xs...)
+@generated function gradient!{T,N,ITPT,IT}(g, sitp::ScaledInterpolation{T,N,ITPT,IT}, xs...)
+    ndims(g) == 1 || throw(ArgumentError("g must be a vector (but had $(ndims(g)) dimensions)"))
+    length(xs) == count_interp_dims(IT, N) || throw(ArgumentError("Must index into $N-dimensional scaled interpolation object with exactly $N indices (you used $(length(xs)))"))
+
+    interp_types = length(IT.parameters) == N ? IT.parameters : tuple([IT.parameters[1] for _ in 1:N]...)
+    interp_dimens = map(it -> interp_types[it] != NoInterp, 1:N)
+    interp_indices = map(i -> interp_dimens[i] ? :(coordlookup(sitp.ranges[$i], xs[$i])) : :(xs[$i]), 1:N)
+
+    quote
+        length(g) == N || throw(ArgumentError(string("g must be a vector of length ", N, " (was ", length(g), ")")))
+        gradient!(g, sitp.itp, $(interp_indices...))
+        for i in eachindex(g)
+            g[i] = rescale_gradient(sitp.ranges[i], g[i])
+        end
+        g
+    end
+end
+
+rescale_gradient(r::LinSpace, g) = g * r.divisor / (r.stop - r.start)
+rescale_gradient(r::FloatRange, g) = g * r.divisor / r.step
+rescale_gradient(r::StepRange, g) = g / r.step
+rescale_gradient(r::UnitRange, g) = g

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -26,7 +26,7 @@ function scale{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ranges::Range..
     ScaledInterpolation(T,N,itp,IT,GT,ranges)
 end
 
-@generated function getindex{T,N,ITPT,IT<:DimSpec}(sitp::ScaledInterpolation{T,N,ITPT,IT}, xs...)
+@generated function getindex{T,N,ITPT,IT<:DimSpec}(sitp::ScaledInterpolation{T,N,ITPT,IT}, xs::Number...)
     length(xs) == N || throw(ArgumentError("Must index into $N-dimensional scaled interpolation object with exactly $N indices (you used $(length(xs)))"))
     interp_types = length(IT.parameters) == N ? IT.parameters : tuple([IT.parameters[1] for _ in 1:N]...)
     interp_dimens = map(it -> interp_types[it] != NoInterp, 1:N)
@@ -59,17 +59,17 @@ coordlookup(r::StepRange, x) = (x - r.start) / r.step + one(eltype(r))
 coordlookup(r::UnitRange, x) = x - r.start + one(eltype(r))
 coordlookup(i::Bool, r::Range, x) = i ? coordlookup(r, x) : convert(typeof(coordlookup(r,x)), x)
 
-gradient{T,N}(sitp::ScaledInterpolation{T,N}, xs...) = gradient!(Array(T,N), sitp, xs...)
-@generated function gradient!{T,N,ITPT,IT}(g, sitp::ScaledInterpolation{T,N,ITPT,IT}, xs...)
-    ndims(g) == 1 || throw(ArgumentError("g must be a vector (but had $(ndims(g)) dimensions)"))
-    length(xs) == count_interp_dims(IT, N) || throw(ArgumentError("Must index into $N-dimensional scaled interpolation object with exactly $N indices (you used $(length(xs)))"))
+gradient{T,N,ITPT,IT<:DimSpec}(sitp::ScaledInterpolation{T,N,ITPT,IT}, xs::Number...) = gradient!(Array(T,count_interp_dims(IT,N)), sitp, xs...)
+@generated function gradient!{T,N,ITPT,IT}(g, sitp::ScaledInterpolation{T,N,ITPT,IT}, xs::Number...)
+    ndims(g) == 1 || throw(DimensionMismatch("g must be a vector (but had $(ndims(g)) dimensions)"))
+    length(xs) == N || throw(DimensionMismatch("Must index into $N-dimensional scaled interpolation object with exactly $N indices (you used $(length(xs)))"))
 
     interp_types = length(IT.parameters) == N ? IT.parameters : tuple([IT.parameters[1] for _ in 1:N]...)
     interp_dimens = map(it -> interp_types[it] != NoInterp, 1:N)
     interp_indices = map(i -> interp_dimens[i] ? :(coordlookup(sitp.ranges[$i], xs[$i])) : :(xs[$i]), 1:N)
 
     quote
-        length(g) == N || throw(ArgumentError(string("g must be a vector of length ", N, " (was ", length(g), ")")))
+        length(g) == $(count_interp_dims(IT, N)) || throw(ArgumentError(string("The length of the provided gradient vector (", length(g), ") did not match the number of interpolating dimensions (", $(count_interp_dims(IT, N)), ")")))
         gradient!(g, sitp.itp, $(interp_indices...))
         for i in eachindex(g)
             g[i] = rescale_gradient(sitp.ranges[i], g[i])

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -1,3 +1,5 @@
+export ScaledInterpolation
+
 type ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
     itp::ITPT
     ranges::RT

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -4,13 +4,13 @@ type ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,
 end
 ScaledInterpolation{T,ITPT,IT,GT,RT}(::Type{T}, N, itp::ITPT, ::Type{IT}, ::Type{GT}, ranges::RT) =
     ScaledInterpolation{T,N,ITPT,IT,GT,RT}(itp, ranges)
-@doc """
+"""
 `scale(itp, xs, ys, ...)` scales an existing interpolation object to allow for indexing using other coordinate axes than unit ranges, by wrapping the interpolation object and transforming the indices from the provided axes onto unit ranges upon indexing.
 
 The parameters `xs` etc must be either ranges or linspaces, and there must be one coordinate range/linspace for each dimension of the interpolation object.
 
 For every `NoInterp` dimension of the interpolation object, the range must be exactly `1:size(itp, d)`.
-""" ->
+"""
 function scale{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ranges::Range...)
     length(ranges) == N || throw(ArgumentError("Must scale $N-dimensional interpolation object with exactly $N ranges (you used $(length(ranges)))"))
     for d in 1:N
@@ -45,11 +45,11 @@ boundstep(r::FloatRange) = r.step / 2
 boundstep(r::StepRange) = r.step / 2
 boundstep(r::UnitRange) = 1//2
 
-@doc """
+"""
 Returns *half* the width of one step of the range.
 
 This function is used to calculate the upper and lower bounds of `OnCell` interpolation objects.
-""" -> boundstep
+""" boundstep
 
 coordlookup(r::LinSpace, x) = (r.divisor * x + r.stop - r.len * r.start) / (r.stop - r.start)
 coordlookup(r::FloatRange, x) = (r.divisor * x - r.start) / r.step + one(eltype(r))
@@ -81,7 +81,8 @@ rescale_gradient(r::FloatRange, g) = g * r.divisor / r.step
 rescale_gradient(r::StepRange, g) = g / r.step
 rescale_gradient(r::UnitRange, g) = g
 
-@doc """
+"""
 `rescale_gradient(r::Range)`
 
-Implements the chain rule dy/dx = dy/du * du/dx for use when calculating gradients with scaled interpolation objects.""" -> rescale_gradient
+Implements the chain rule dy/dx = dy/du * du/dx for use when calculating gradients with scaled interpolation objects.
+""" rescale_gradient

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -27,7 +27,7 @@ etpf = @inferred(extrapolate(itpg, NaN))
 @test_throws BoundsError etpf[2.5,2]
 @test_throws ErrorException etpf[2.5,2,1]  # this will probably become a BoundsError someday
 
-etpf = @inferred(FilledInterpolation(itpg, 'x'))
+etpf = @inferred(FilledExtrapolation(itpg, 'x'))
 @test_approx_eq etpf[2] f(2)
 @test etpf[-1.5] == 'x'
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,9 @@ include("b-splines/runtests.jl")
 # extrapolation tests
 include("extrapolation/runtests.jl")
 
+# scaling tests
+include("scaling/runtests.jl")
+
 # # test gradient evaluation
 include("gradient.jl")
 

--- a/test/scaling/dimspecs.jl
+++ b/test/scaling/dimspecs.jl
@@ -1,0 +1,26 @@
+module ScalingDimspecTests
+
+using Interpolations, DualNumbers, Base.Test
+
+xs = -pi:(2pi/10):pi-2pi/10
+ys = -2:.1:2
+f(x,y) = sin(x) * y^2
+
+itp = interpolate(Float64[f(x,y) for x in xs, y in ys], Tuple{BSpline(Quadratic(Periodic)), BSpline(Linear)}, OnGrid)
+sitp = scale(itp, xs, ys)
+
+# Don't test too near the edges until issue #64 is resolved
+for (ix,x0) in enumerate(xs[5:end-5]), (iy,y0) in enumerate(ys[2:end-1])
+    x, y = x0 + 2pi/20, y0 + .05
+    @test_approx_eq sitp[x0, y0] f(x0,y0)
+    @test_approx_eq_eps sitp[x0, y0] f(x0,y0) 0.05
+
+    g = gradient(sitp, x, y)
+    fx = epsilon(f(dual(x,1), y))
+    fy = (f(x, ys[iy+2]) - f(x, ys[iy+1])) / (ys[iy+2] - ys[iy+1])
+
+    @test_approx_eq_eps g[1] fx 0.15
+    @test_approx_eq_eps g[2] fy 0.05 # gradients for linear interpolation is "easy"
+end
+
+end

--- a/test/scaling/dimspecs.jl
+++ b/test/scaling/dimspecs.jl
@@ -9,18 +9,15 @@ f(x,y) = sin(x) * y^2
 itp = interpolate(Float64[f(x,y) for x in xs, y in ys], Tuple{BSpline(Quadratic(Periodic)), BSpline(Linear)}, OnGrid)
 sitp = scale(itp, xs, ys)
 
-# Don't test too near the edges until issue #64 is resolved
-for (ix,x0) in enumerate(xs[5:end-5]), (iy,y0) in enumerate(ys[2:end-1])
-    x, y = x0 + 2pi/20, y0 + .05
-    @test_approx_eq sitp[x0, y0] f(x0,y0)
-    @test_approx_eq_eps sitp[x0, y0] f(x0,y0) 0.05
+for (ix,x) in enumerate(xs), (iy,y) in enumerate(ys)
+    @test_approx_eq_eps sitp[x,y] f(x,y) sqrt(eps(1.0))
 
     g = gradient(sitp, x, y)
-    fx = epsilon(f(dual(x,1), y))
-    fy = (f(x, ys[iy+2]) - f(x, ys[iy+1])) / (ys[iy+2] - ys[iy+1])
+    fx = epsilon(sitp[dual(x,1), dual(y,0)])
+    fy = epsilon(sitp[dual(x,0), dual(y,1)])
 
-    @test_approx_eq_eps g[1] fx 0.15
-    @test_approx_eq_eps g[2] fy 0.05 # gradients for linear interpolation is "easy"
+    @test_approx_eq_eps g[1] fx sqrt(eps(1.0))
+    @test_approx_eq_eps g[2] fy sqrt(eps(1.0))
 end
 
 end

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -1,0 +1,38 @@
+module ScalingNoInterpTests
+
+using Interpolations, Base.Test
+
+xs = -pi:2pi/10:pi
+f1(x) = sin(x)
+f2(x) = cos(x)
+f3(x) = sin(x) .* cos(x)
+f(x,y) = y == 1 ? f1(x) : (y == 2 ? f2(x) : (y == 3 ? f3(x) : error("invalid value for y (must be 1, 2 or 3, you used $y)")))
+ys = 1:3
+
+A = hcat(f1(xs), f2(xs), f3(xs))
+
+itp = interpolate(A, Tuple{BSpline(Quadratic(Periodic)), NoInterp}, OnGrid)
+sitp = scale(itp, xs, ys)
+
+for (ix,x0) in enumerate(xs[1:end-1]), y0 in ys
+    x,y = x0, y0
+    @test_approx_eq_eps sitp[x,y] f(x,y) .05
+end
+
+# Test error messages for incorrect initialization
+function message_is(message)
+	r -> r.err.msg == message || error("Incorrect error message: expected '$message' but was '$(r.err.msg)'")
+end
+Test.with_handler(message_is("Must scale 2-dimensional interpolation object with exactly 2 ranges (you used 1)")) do
+	@test scale(itp, xs)
+end
+Test.with_handler(message_is("NoInterp dimension 2 must be scaled with unit range 1:3")) do
+	@test scale(itp, xs, -1:1)
+end
+Test.with_handler(message_is("The length of the range in dimension 1 (8) did not equal the size of the interpolation object in that direction (11)")) do
+	@test scale(itp, -pi:2pi/7:pi, 1:3)
+end
+Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
+	@test sitp[2.3]
+end
+end

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -19,6 +19,8 @@ for (ix,x0) in enumerate(xs[1:end-1]), y0 in ys
     @test_approx_eq_eps sitp[x,y] f(x,y) .05
 end
 
+@test length(gradient(sitp, pi/3, 2)) == 1
+
 # Test error messages for incorrect initialization
 function message_is(message)
 	r -> r.err.msg == message || error("Incorrect error message: expected '$message' but was '$(r.err.msg)'")

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -35,4 +35,10 @@ end
 Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
 	@test sitp[2.3]
 end
+Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
+	@test gradient(sitp, 2.3)
+end
+Test.with_handler(message_is("The length of the provided gradient vector (2) did not match the number of interpolating dimensions (1)")) do
+	@test gradient!(Array(Float64, 2), sitp, 2.3, 2)
+end
 end

--- a/test/scaling/runtests.jl
+++ b/test/scaling/runtests.jl
@@ -1,0 +1,4 @@
+include("scaling.jl")
+include("dimspecs.jl")
+include("nointerp.jl")
+include("withextrap.jl")

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -1,0 +1,52 @@
+module ScalingTests
+
+using Interpolations
+using Base.Test
+
+# Model linear interpolation of y = -3 + .5x by interpolating y=x
+# and then scaling to the new x range
+
+itp = interpolate(1:1.0:10, BSpline(Linear), OnGrid)
+
+sitp = scale(itp, -3:.5:1.5)
+
+for (x,y) in zip(-3:.05:1.5, 1:.1:10)
+    @test_approx_eq sitp[x] y
+end
+
+# Verify that it works in >1D, with different types of ranges
+
+gauss(phi, mu, sigma) = exp(-(phi-mu)^2 / (2sigma)^2)
+testfunction(x,y) = gauss(x, 0.5, 4) * gauss(y, -.5, 2)
+
+xs = -5:.5:5
+ys = -4:.2:4
+zs = Float64[testfunction(x,y) for x in xs, y in ys]
+
+itp2 = interpolate(zs, BSpline(Quadratic(Flat)), OnGrid)
+sitp2 = scale(itp2, xs, ys)
+
+for x in xs, y in ys
+    @test_approx_eq testfunction(x,y) sitp2[x,y]
+end
+
+# Test gradients of scaled grids
+xs = -pi:.1:pi
+ys = sin(xs)
+itp = interpolate(ys, BSpline(Linear), OnGrid)
+sitp = scale(itp, xs)
+
+for x in -pi:.1:pi
+    g = @inferred(gradient(sitp, x))[1]
+    @test_approx_eq_eps cos(x) g .05
+end
+
+# Verify that return types are reasonable
+@inferred(getindex(sitp2, -3.4, 1.2))
+@inferred(getindex(sitp2, -3, 1))
+@inferred(getindex(sitp2, -3.4, 1))
+
+sitp32 = scale(interpolate(Float32[testfunction(x,y) for x in -5:.5:5, y in -4:.2:4], BSpline(Quadratic(Flat)), OnGrid), -5f0:.5f0:5f0, -4f0:.2f0:4f0)
+@test typeof(@inferred(getindex(sitp32, -3.4f0, 1.2f0))) == Float32
+
+end

--- a/test/scaling/withextrap.jl
+++ b/test/scaling/withextrap.jl
@@ -1,0 +1,40 @@
+
+module ScalingWithExtrapTests
+
+using Interpolations, Base.Test
+
+xs = linspace(-5, 5, 10)
+ys = sin(xs)
+
+function run_tests{T,N,IT}(sut::Interpolations.AbstractInterpolation{T,N,IT,OnGrid}, itp)
+    for x in xs
+        @test_approx_eq_eps sut[x] sin(x) sqrt(eps(sin(x)))
+    end
+    @test sut[-5] == sut[-5.1] == sut[-15.8] == sut[-Inf] == itp[1]
+    @test sut[5] == sut[5.1] == sut[15.8] == sut[Inf] == itp[end]
+end
+
+function run_tests{T,N,IT}(sut::Interpolations.AbstractInterpolation{T,N,IT,OnCell}, itp)
+    halfcell = (xs[2] - xs[1]) / 2
+
+    for x in (5 + halfcell, 5 + 1.1halfcell, 15.8, Inf)
+        @test sut[-x] == itp[.5]
+        @test sut[x] == itp[end+.5]
+    end
+end
+
+for GT in (OnGrid, OnCell)
+    itp = interpolate(ys, BSpline(Quadratic(Flat)), GT)
+
+    # Test extrapolating, then scaling
+    eitp = extrapolate(itp, Flat)
+    seitp = scale(eitp, xs)
+    run_tests(seitp, itp)
+
+    # Test scaling, then extrapolating
+    sitp = scale(itp, xs)
+    esitp = extrapolate(sitp, Flat)
+    run_tests(esitp, itp)
+end
+
+end


### PR DESCRIPTION
This is a start at implementing the functionality provided to Grid.jl by the CoordInterpGrid type, and in fact the code here is heavily based on that contributed by @simonbyrne there.

Simon, do you have any objections to me basing this implementation off of your code? If so, please feel free to object here, and I'll remove this and come up with something from scratch. It's just that borrowing is so easy ;)

The basic idea is that you can do

```julia
f(x) = exp(-x.^2 ./ 4)
xs = -5:.2:5
ys = f(xs)
itp = interpolate(ys, BSpline(Linear), OnGrid)

s = scale(itp, xs)   # now, s[-2.3] ~= f(-2.3)
```

To scale in higher dimensions, you just tuck on more ranges at the end, one range for each dimension (i.e. `scale(itp2, xs, ys)` to scale a 2D interpolation object).

This doesn't fully handle everything we want yet - for one thing, there's no scaling of the coordinates that works for gradients. Also, in Grid.jl @timholy added specializations for dimensions 1-4 that avoided splatting. I'd like to see if it's possible to do this using staged functions instead of explicitly writing them out, but this might not be fully performant yet. It also needs documentation.

However, if anyone has any opinions about the API, this is as good a time as any to raise them.

Todo:

* [x] basic implementation
* [x] gradient evaluation
* [x] make sure it works with `DimSpec`s and `NoInterp` dimensions
* [x] tests for combinations with `extrapolate` (both `extrapolate(scale(...))` and `scale(extrapolate(...))`)
* [x] make sure scaled interpolation objects display nicely
* [x] documentation