### PR TITLE
Simplify indexing

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -54,14 +54,6 @@ size{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->size(itp,i), N)::NTuple{N
 size(exp::AbstractExtrapolation, d) = size(exp.itp, d)
 gridtype{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}) = GT
 
-# Fix display issues by defining odd combinations of dimensionality and index
-function getindex{T}(itp::AbstractInterpolation{T,1}, x::Real, y::Real)
-    if y != 1
-        throw(ArgumentError("Cannot index into 1D interpolation with two indices unless y == 1 (y == $y)"))
-    end
-    itp[x]
-end
-
 @inline gradient{T,N}(itp::AbstractInterpolation{T,N}, xs...) = gradient!(Array(T,N), itp, xs...)
 
 include("b-splines/b-splines.jl")

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -2,6 +2,8 @@ using Base.Cartesian
 
 import Base.getindex
 
+Base.linearindexing{T<:AbstractInterpolation}(::Type{T}) = Base.LinearSlow()
+
 function getindex_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}})
     meta = Expr(:meta, :inline)
     quote

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -23,32 +23,6 @@ function getindex_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
     end
 end
 
-# Resolve ambiguity with general array indexing,
-#   getindex{T,N}(A::AbstractArray{T,N}, I::AbstractArray{T,N})
-function getindex{T,N}(itp::BSplineInterpolation{T,N}, I::AbstractArray{T,N})
-    error("Array indexing is not defined for interpolation objects.")
-end
-
-# Resolve ambiguity with colon indexing for 1D interpolations
-#   getindex{T}(A::AbstractArray{T,1}, C::Colon)
-function getindex{T}(itp::BSplineInterpolation{T,1}, c::Colon)
-    error("Colon indexing is not supported for interpolation objects")
-end
-
-# Resolve ambiguity with indexing with Real indices
-#   getindex{T,N}(A::AbstractArray{T,N}, x::Real...)
-@generated function getindex{T,N,TCoefs,IT<:BSpline}(itp::BSplineInterpolation{T,N,TCoefs,IT}, xs::Real...)
-    getindex_impl(itp)
-end
-
-# Linear indexing is supported only for 1D interpolations
-@generated function getindex{T,N}(itp::BSplineInterpolation{T,N}, xs::Real)
-    if N > 1
-        error("Linear indexing is not supported for interpolation objects")
-    end
-    getindex_impl(itp)
-end
-
 @generated function getindex{T,N}(itp::BSplineInterpolation{T,N}, xs...)
     getindex_impl(itp)
 end

--- a/src/extrapolation/constant.jl
+++ b/src/extrapolation/constant.jl
@@ -7,11 +7,11 @@ ConstantExtrapolation{T,ITP,IT,GT}(::Type{T}, N, itp::ITP, ::Type{IT}, ::Type{GT
 extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, ::Type{Flat}) =
     ConstantExtrapolation(T,N,itp,IT,GT)
 
-function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnGrid}}, xs)
-    :(xs = clamp(xs, 1, size(exp,1)))
+function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnGrid}}, x)
+    :(x = clamp(x, 1, size(exp,1)))
 end
-function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnCell}}, xs)
-    :(xs = clamp(xs, .5, size(exp,1)+.5))
+function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnCell}}, x)
+    :(x = clamp(x, .5, size(exp,1)+.5))
 end
 function extrap_prep{T,N,ITP,IT}(exp::Type{ConstantExtrapolation{T,N,ITP,IT,OnGrid}}, xs...) 
     :(@nexprs $N d->(@show xs[d] = clamp(xs[d], 1, size(exp,d))))

--- a/src/extrapolation/constant.jl
+++ b/src/extrapolation/constant.jl
@@ -14,8 +14,8 @@ function extrap_prep{T,ITP,IT}(exp::Type{ConstantExtrapolation{T,1,ITP,IT,OnCell
     :(x = clamp(x, .5, size(exp,1)+.5))
 end
 function extrap_prep{T,N,ITP,IT}(exp::Type{ConstantExtrapolation{T,N,ITP,IT,OnGrid}}, xs...) 
-    :(@nexprs $N d->(@show xs[d] = clamp(xs[d], 1, size(exp,d))))
+    :(@nexprs $N d->(xs[d] = clamp(xs[d], 1, size(exp,d))))
 end
 function extrap_prep{T,N,ITP,IT}(exp::Type{ConstantExtrapolation{T,N,ITP,IT,OnCell}}, xs...)
-    :(@nexprs $N d->(@show xs[d] = clamp(xs[d], .5, size(exp,d)+.5)))
+    :(@nexprs $N d->(xs[d] = clamp(xs[d], .5, size(exp,d)+.5)))
 end

--- a/src/extrapolation/indexing.jl
+++ b/src/extrapolation/indexing.jl
@@ -1,37 +1,13 @@
-function extrap_impl{T<:AbstractExtrapolation}(exp::Type{T}, xs...)
+@generated function getindex{T}(exp::AbstractExtrapolation{T,1}, x)
+    quote
+        $(extrap_prep(exp, x))
+        exp.itp[x]
+    end
+end
+
+@generated function getindex{T,N,ITP,GT}(exp::AbstractExtrapolation{T,N,ITP,GT}, xs...)
     quote
         $(extrap_prep(exp, xs...))
         exp.itp[xs...]
     end
-end
-
-
-# Resolve ambiguity with general array indexing,
-#   getindex{T,N}(A::AbstractArray{T,N}, I::AbstractArray{T,N})
-function getindex{T,N}(exp::AbstractExtrapolation{T,N}, I::AbstractArray{T,N})
-    error("Array indexing is not defined for interpolation objects.")
-end
-
-# Resolve ambiguity with colon indexing for 1D interpolations
-#   getindex{T}(A::AbstractArray{T,1}, C::Colon)
-function getindex{T}(exp::AbstractExtrapolation{T,1}, c::Colon)
-    error("Colon indexing is not supported for interpolation objects")
-end
-
-# Resolve ambiguity with indexing with Real indices
-#   getindex{T,N}(A::AbstractArray{T,N}, x::Real...)
-@generated function getindex{T,N,ITP,GT}(exp::AbstractExtrapolation{T,N,ITP,GT}, xs::Real...)
-    :($extrap_impl(exp, xs...))
-end
-
-# Linear indexing is supported only for 1D interpolations
-@generated function getindex{T,N}(exp::AbstractExtrapolation{T,N}, xs::Real)
-    if N > 1
-        error("Linear indexing is not supported for interpolation objects")
-    end
-    :($(extrap_impl(exp, xs)))
-end
-
-@generated function getindex{T,N,ITP,GT}(exp::AbstractExtrapolation{T,N,ITP,GT}, xs...)
-    :($(extrap_impl(exp, xs...)))
 end

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -12,7 +12,6 @@ itpg = interpolate(A, BSpline(Linear), OnGrid)
 expg = extrapolate(itpg, Flat)
 
 @test expg[-3] == expg[-4.5] == expg[0.9] == expg[1.0] == A[1]
-#@test 
-expg[10.1] == expg[11]# == expg[148.298452] == A[end]
+@test expg[10.1] == expg[11] == expg[148.298452] == A[end]
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,6 @@ include("gradient.jl")
 # Tests copied from Grid.jl's old test suite
 #include("grid.jl")
 
-println("all tests passed")
-
 end
 
 nothing


### PR DESCRIPTION
This removes some code that's no longer needed, thanks to JuliaLang/julia#10525. Hopefully, this will make it a little easier to extend the package in the future.

@timholy I assume that the method taking a `CartesianIndex` is an optimization. Is this somehow also provided by base Julia now?