### PR TITLE
RFC: Convert integer inputs to float before interpolating

### DIFF
--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -49,6 +49,7 @@ end
 interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate(Float64, A, IT, GT)
 interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate(Float32, A, IT, GT)
 interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate(Rational{Int}, A, IT, GT)
+interpolate{T<:Integer,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{T}, ::Type{IT}, ::Type{GT}) = interpolate(float(A), IT, GT)
 
 interpolate!{TWeights,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = BSplineInterpolation(TWeights, prefilter!(TWeights, A, IT, GT), IT, GT, Val{0}())
 interpolate!{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate!(Float64, A, IT, GT)

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -42,14 +42,17 @@ padextract(pad::Tuple{Vararg{Integer}}, d) = pad[d]
     end
 end
 
-function interpolate{TWeights,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT})
-    Apad, Pad = prefilter(TWeights, A, IT, GT)
+function interpolate{TWeights,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(::Type{TWeights}, ::Type{TCoefs}, A, ::Type{IT}, ::Type{GT})
+    Apad, Pad = prefilter(TWeights, TCoefs, A, IT, GT)
     BSplineInterpolation(TWeights, Apad, IT, GT, Pad)
 end
-interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate(Float64, A, IT, GT)
-interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate(Float32, A, IT, GT)
-interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate(Rational{Int}, A, IT, GT)
-interpolate{T<:Integer,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{T}, ::Type{IT}, ::Type{GT}) = interpolate(float(A), IT, GT)
+interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate(Float64, eltype(A), A, IT, GT)
+interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate(Float32, Float32, A, IT, GT)
+interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate(Rational{Int}, Rational{Int}, A, IT, GT)
+function interpolate{T<:Integer,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{T}, ::Type{IT}, ::Type{GT})
+    TFloat = typeof(float(zero(T)))
+    interpolate(TFloat, TFloat, A, IT, GT)
+end
 
 interpolate!{TWeights,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = BSplineInterpolation(TWeights, prefilter!(TWeights, A, IT, GT), IT, GT, Val{0}())
 interpolate!{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate!(Float64, A, IT, GT)

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -15,32 +15,34 @@ function padded_index{N,pad}(sz::NTuple{N,Int}, ::Val{pad})
     end
     ind,szpad
 end
-function copy_with_padding{IT<:DimSpec{InterpolationType}}(A, ::Type{IT})
+
+copy_with_padding{IT}(A, ::Type{IT}) = copy_with_padding(eltype(A), A, IT)
+function copy_with_padding{TCoefs,IT<:DimSpec{InterpolationType}}(::Type{TCoefs}, A, ::Type{IT})
     Pad = padding(IT)
     ind,sz = padded_index(size(A), Pad)
     if sz == size(A)
-        coefs = copy(A)
+        coefs = copy!(similar(A,TCoefs), A)
     else
-        coefs = zeros(eltype(A), sz...)
+        coefs = zeros(TCoefs, sz...)
         coefs[ind...] = A
     end
     coefs, Pad
 end
 
 prefilter!{TWeights, IT<:BSpline, GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = A
-prefilter{TWeights, IT<:BSpline, GT<:GridType}(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) = prefilter!(TWeights, copy(A), IT, GT), Val{0}()
+prefilter{TWeights, TCoefs, IT<:BSpline, GT<:GridType}(::Type{TWeights}, ::Type{TCoefs}, A, ::Type{IT}, ::Type{GT}) = prefilter!(TWeights, copy!(similar(A,TCoefs), A), IT, GT), Val{0}()
 
-function prefilter{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
-    ::Type{TWeights}, A::Array{TCoefs,N}, ::Type{BSpline{IT}}, ::Type{GT}
+function prefilter{TWeights,TCoefs,TSrc,N,IT<:Quadratic,GT<:GridType}(
+    ::Type{TWeights}, ::Type{TCoefs}, A::Array{TSrc,N}, ::Type{BSpline{IT}}, ::Type{GT}
     )
-    ret, Pad = copy_with_padding(A, BSpline{IT})
+    ret, Pad = copy_with_padding(TCoefs,A, BSpline{IT})
     prefilter!(TWeights, ret, BSpline{IT}, GT), Pad
 end
 
-function prefilter{TWeights,TCoefs,N,IT<:Tuple{Vararg{BSpline}},GT<:DimSpec{GridType}}(
-    ::Type{TWeights}, A::Array{TCoefs,N}, ::Type{IT}, ::Type{GT}
+function prefilter{TWeights,TCoefs,TSrc,N,IT<:Tuple{Vararg{BSpline}},GT<:DimSpec{GridType}}(
+    ::Type{TWeights}, ::Type{TCoefs}, A::Array{TSrc,N}, ::Type{IT}, ::Type{GT}
     )
-    ret, Pad = copy_with_padding(A, IT)
+    ret, Pad = copy_with_padding(TCoefs,A, IT)
     prefilter!(TWeights, ret, IT, GT), Pad
 end
 

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -1,0 +1,14 @@
+module Issue34
+
+using Interpolations, Base.Test
+
+A = rand(1:20, 3, 3)
+
+# In #34, this incantation throws
+itp = interpolate(A, BSpline(Quadratic(Flat)), OnCell)
+# Sanity check that not only don't throw, but actually interpolate
+for i in 1:3, j in 1:3
+    @test_approx_eq itp[i,j] A[i,j]
+end
+
+end

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -2,12 +2,12 @@ module Issue34
 
 using Interpolations, Base.Test
 
-A = rand(1:20, 3, 3)
+A = rand(1:20, 100, 100)
 
 # In #34, this incantation throws
 itp = interpolate(A, BSpline(Quadratic(Flat)), OnCell)
 # Sanity check that not only don't throw, but actually interpolate
-for i in 1:3, j in 1:3
+for i in 1:size(A,1), j in 1:size(A,2)
     @test_approx_eq itp[i,j] A[i,j]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,8 @@ include("gradient.jl")
 # Tests copied from Grid.jl's old test suite
 #include("grid.jl")
 
+include("issues/runtests.jl")
+
 end
 
 nothing


### PR DESCRIPTION
This should fix #38, but I'm quite sure the solution is not optimal, for the following reasons:

* It converts integer inputs to floats for *all* inputs, but it shouldn't be necessary if no interpolations are to be done in higher dimensions than linear, since then there's no matrix inversion involved.
* I'm quite sure there's an extra copy now - first from `A` to `float(A)`, then from `float(A)` before prefiltering, but if I forward to `interpolate!` instead of `interpolate` I get garbage results in my tests. (Maybe I just misunderstood how in-place interpolation is implemented, and tested too close to the edges...)