### PR TITLE
Allow more eltypes on the input array

### DIFF
--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -46,7 +46,8 @@ function interpolate{TWeights,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}
     Apad, Pad = prefilter(TWeights, TCoefs, A, IT, GT)
     BSplineInterpolation(TWeights, Apad, IT, GT, Pad)
 end
-interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate(Float64, eltype(A), A, IT, GT)
+interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray, ::Type{IT}, ::Type{GT}) = interpolate(Float64, Float64, A, IT, GT)
+interpolate{T<:Number,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{T}, ::Type{IT}, ::Type{GT}) = interpolate(Float64, eltype(A), A, IT, GT)
 interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Float32}, ::Type{IT}, ::Type{GT}) = interpolate(Float32, Float32, A, IT, GT)
 interpolate{IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{Rational{Int}}, ::Type{IT}, ::Type{GT}) = interpolate(Rational{Int}, Rational{Int}, A, IT, GT)
 function interpolate{T<:Integer,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}(A::AbstractArray{T}, ::Type{IT}, ::Type{GT})


### PR DESCRIPTION
There are still some issues with the `copy_with_padding` function used when constructing interpolation objects; specifically, requires `zero(TCoefs)` to be defined. This is reasonable, because there is a fallback `zero(Number)` that will kick in for most sensible inputs, but it's quite easy to hit an error anyway - consider the following Julia REPL session:

```
julia> using Interpolations

jula> xs, ys = 1:15, 1:10;

julia> zs = [sqrt(x^2 + y^2) for x in xs, y in ys];

julia> itp = interpolate(zs, BSpline(Quadratic(Line)), OnGrid)
LoadError: MethodError: `zero` has no method matching zero(::Type{Any})
while loading In[12], in expression starting on line 4

 in copy_with_padding at /home/tlycken/.julia/v0.4/Interpolations/src/b-splines/prefiltering.jl:26
 in prefilter at /home/tlycken/.julia/v0.4/Interpolations/src/b-splines/prefiltering.jl:38
 in interpolate at /home/tlycken/.julia/v0.4/Interpolations/src/b-splines/b-splines.jl:46
 in interpolate at /home/tlycken/.julia/v0.4/Interpolations/src/b-splines/b-splines.jl:49
```

It's quite easy to blame this on the user - the problem is that `zs` is an `Array{Any}` rather than `Array{Float64}` (and interpolation on `Any` is just silly) - but since it's likely that new users will actually stumble on this, I think it's worth fixing anyway.

This adds a method so that `A::AbstractArray{T<:Number}` defaults `TCoefs == eltype(A)` while `A::AbstractArray` defaults `TCoefs == Float64` (cf table in #51).