### PR TITLE
Restrict scalar indexing to Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,21 @@ and `Rational`, but also multi-valued types like `RGB` color vectors.
 Positions `(x, y, ...)` are n-tuples of numbers. Typically these will
 be real-valued (not necessarily integer-valued), but can also be of types
 such as [DualNumbers](https://github.com/JuliaDiff/DualNumbers.jl) if
-you want to verify the computed value of gradients.
+you want to verify the computed value of gradients. You can also use
+Julia's iterator objects, e.g.,
+
+```jl
+function ongrid!(dest, itp)
+    for I in CartesianRange(size(itp))
+        dest[I] = itp[I]
+    end
+end
+```
+would store the on-grid value at each grid point of `itp` in the output `dest`.
+Finally, courtesy of Julia's indexing rules, you can also use
+```jl
+fine = itp[linspace(1,10,1001), linspace(1,15,201)]
+```
 
 
 ## Control of interpolation algorithm
@@ -96,7 +110,7 @@ itp = interpolate(A, Tuple{BSpline{Linear}, BSpline{NoInterp}}, OnGrid)
 v = itp[3.65, 5]  # returns  0.35*A[3,5] + 0.65*A[4,5]
 ```
 There are more options available, for example:
-```
+```jl
 # In-place interpolation
 itp = interpolate!(A, BSpline{Quadratic{InPlace}}, OnCell)
 ```

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -23,12 +23,8 @@ function getindex_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
     end
 end
 
-@generated function getindex{T,N}(itp::BSplineInterpolation{T,N}, xs...)
+@generated function getindex{T,N}(itp::BSplineInterpolation{T,N}, xs::Number...)
     getindex_impl(itp)
-end
-
-@generated function getindex{T,N}(itp::BSplineInterpolation{T,N}, index::CartesianIndex{N})
-    :(getindex(itp, $(Base.IteratorsMD.cartindex_exprs((index,), (:index,))...)))
 end
 
 function gradient_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}})
@@ -62,7 +58,7 @@ function gradient_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
 end
 
 
-@generated function gradient!{T,N}(g::AbstractVector, itp::BSplineInterpolation{T,N}, xs...)
+@generated function gradient!{T,N}(g::AbstractVector, itp::BSplineInterpolation{T,N}, xs::Number...)
     length(xs) == N || error("Can only be called with $N indexes")
     gradient_impl(itp)
 end


### PR DESCRIPTION
This lets us exploit Julia's new indexing utilities.

For the `linspace` thing to work, it will require a to-be-submitted julia PR, to which I'll link shortly.
