### PR TITLE
solves #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ itp = interpolate(A, options...)
 ```
 where `options...` (discussed below) controls the type of
 interpolation you want to perform.  This syntax assumes that the
-samples in `A` are equally-spaced.  If the spacing between adjacent
-samples differs, then you should use the syntax
-```jl
-itp = interpolate(knots, A, options...)
-```
-where `knots = (xknots, yknots, ...)` specifies the positions along
-each axis at which the array `A` is sampled.
+samples in `A` are equally-spaced. 
 
 To evaluate the interpolation at position `(x, y, ...)`, simply do
 ```jl
@@ -132,6 +126,18 @@ which destroys the input `A` but also does not need to allocate as much memory.
 These use a very similar syntax to BSplines, with the major exception
 being that one does not get to choose the grid representation (they
 are all `OnGrid`).
+```jl
+A = rand(8,20)
+itp = interpolate(A, Gridded{Linear})
+itp[4,1.2] 
+```
+
+If the spacing between adjacent samples differs, then you can use the syntax
+```jl
+itp = interpolate(knots, A, options...)
+```
+where `knots = (xknots, yknots, ...)` specifies the positions along
+each axis at which the array `A` is sampled.
 
 For example:
 ```jl

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -22,6 +22,7 @@ function GriddedInterpolation{N,TCoefs,TWeights<:Real,IT<:DimSpec{Gridded},pad}(
         length(k) == size(A, d) || throw(DimensionMismatch("knot vectors must have the same number of elements as the corresponding dimension of the array"))
         length(k) == 1 && error("dimensions of length 1 not yet supported")  # FIXME
         issorted(k) || error("knot-vectors must be sorted in increasing order")
+        iextract(IT, d) != Gridded{NoInterp} || k == collect(1:size(A, d)) || error("knot-vector should be the range 1:$(size(A,d)) for the method Gridded{NoInterp}")
     end
     c = one(TWeights)
     for _ in 2:N

--- a/test/gridded/mixed.jl
+++ b/test/gridded/mixed.jl
@@ -19,4 +19,5 @@ knots = ([x^2 for x = 1:8], [0.2y for y = 1:20])
 itp = interpolate(knots, A, Gridded{Linear})
 @test_approx_eq itp[4,1.2] A[2,6]
 
+@test_throws  ErrorException interpolate(knots, A, Tuple{Gridded{Linear} ,Gridded{NoInterp}})
 end


### PR DESCRIPTION
- Returns error when using Grid{NoInterp} without the range 1:size(A, d)
- moves discussion of knots in the subsection for `Gridded`