### PR TITLE
Re-include tests with other types

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,8 @@ include("gradient.jl")
 # gridded interpolation tests
 include("gridded/runtests.jl")
 
-# # test interpolation with specific types
-# include("typing.jl")
+# test interpolation with specific types
+include("typing.jl")
 
 # Tests copied from Grid.jl's old test suite
 #include("grid.jl")

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -8,7 +8,7 @@ g(x) = convert(Float32, 3x^2/(nx-1))
 
 A = Float32[f(x) for x in 1:nx]
 
-itp = Interpolation(A, Quadratic(Flat(), OnCell()), ExtrapConstant())
+itp = interpolate(A, BSpline(Quadratic(Flat)), OnCell)
 
 # display(plot(
 #     layer(x=1:nx,y=[f(x) for x in 1:1//1:nx],Geom.point),
@@ -27,11 +27,12 @@ end
 
 @test typeof(gradient(itp, 3.5)[1]) == Float32
 
-if Base.VERSION >= v"0.4-" # This doesn't work on 0.3 due to rational errors in linalg
-    # Rational element types
-    R = Rational{Int}[x^2//10 for x in 1:10]
-    itp = Interpolation(R, Quadratic(Free(),OnCell()), ExtrapNaN())
-    @test itp[11//10] == (11//10)^2//10
-end
+# Rational element types
+R = Rational{Int}[x^2//10 for x in 1:10]
+itp = interpolate(R, BSpline(Quadratic(Free)), OnCell)
+itp[11//10]
+
+@test typeof(itp[11//10]) == Rational{Int}
+@test itp[11//10] == (11//10)^2//10
 
 end


### PR DESCRIPTION
I guess these were excluded when even before we realized we needed `SimpleRatio`s, but I think it's time to include them again.

Perhaps we should add some more in the process, but my mind is all on getting #47 ready to merge...