### PR TITLE
RFC: Rename `FilledInterpolation` -> `FilledExtrapolation`

### DIFF
--- a/perf/run_shootout.jl
+++ b/perf/run_shootout.jl
@@ -16,7 +16,7 @@ make_knots(A) = ntuple(d->collect(linspace(1,size(A,d),size(A,d))), ndims(A))
 make_xi(A)    = ntuple(d->collect(linspace(2,size(A,d)-1,size(A,d)-2)), ndims(A))
 
 ## Interpolations and Grid
-function evaluate_grid(itp::Union(Array,Interpolations.AbstractInterpolation,Grid.InterpGrid), A)
+function evaluate_grid(itp::Union{Array,Interpolations.AbstractInterpolation,Grid.InterpGrid), A}
     s = zero(eltype(itp)) + zero(eltype(itp))
     for I in iterrange(itp)
         s += itp[I]
@@ -58,7 +58,7 @@ function evaluate_grid(itp::Dierckx.Spline2D, A)
 end
 
 # Slow approach for Dierckx
-function evaluate_grid_scalar(itp::Union(Dierckx.Spline1D,Dierckx.Spline2D), A)
+function evaluate_grid_scalar(itp::Union{Dierckx.Spline1D,Dierckx.Spline2D), A}
     T = eltype(A)
     s = zero(T) + zero(T)
     for I in iterrange(A)

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -33,7 +33,7 @@ abstract GridType
 immutable OnGrid <: GridType end
 immutable OnCell <: GridType end
 
-typealias DimSpec{T} Union(T,Tuple{Vararg{Union(T,NoInterp)}},NoInterp)
+typealias DimSpec{T} Union{T,Tuple{Vararg{Union{T,NoInterp}}},NoInterp}
 
 abstract AbstractInterpolation{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}} <: AbstractArray{T,N}
 abstract AbstractExtrapolation{T,N,ITPT,IT,GT} <: AbstractInterpolation{T,N,IT,GT}

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -39,7 +39,7 @@ function prefilter{TWeights,TCoefs,TSrc,N,IT<:Quadratic,GT<:GridType}(
     prefilter!(TWeights, ret, BSpline{IT}, GT), Pad
 end
 
-function prefilter{TWeights,TCoefs,TSrc,N,IT<:Tuple{Vararg{Union(BSpline,NoInterp)}},GT<:DimSpec{GridType}}(
+function prefilter{TWeights,TCoefs,TSrc,N,IT<:Tuple{Vararg{Union{BSpline,NoInterp}}},GT<:DimSpec{GridType}}(
     ::Type{TWeights}, ::Type{TCoefs}, A::Array{TSrc,N}, ::Type{IT}, ::Type{GT}
     )
     ret, Pad = copy_with_padding(TCoefs,A, IT)
@@ -59,7 +59,7 @@ function prefilter!{TWeights,TCoefs,N,IT<:Quadratic,GT<:GridType}(
     ret
 end
 
-function prefilter!{TWeights,TCoefs,N,IT<:Tuple{Vararg{Union(BSpline,NoInterp)}},GT<:DimSpec{GridType}}(
+function prefilter!{TWeights,TCoefs,N,IT<:Tuple{Vararg{Union{BSpline,NoInterp}}},GT<:DimSpec{GridType}}(
     ::Type{TWeights}, ret::Array{TCoefs,N}, ::Type{IT}, ::Type{GT}
     )
     local buf, shape, retrs

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -24,7 +24,7 @@ function define_indices_d(::Type{BSpline{Quadratic{Periodic}}}, d, pad)
         $symixm = mod1($symix - 1, size(itp,$d))
     end
 end
-function define_indices_d{BC<:Union(InPlace,InPlaceQ)}(::Type{BSpline{Quadratic{BC}}}, d, pad)
+function define_indices_d{BC<:Union{InPlace,InPlaceQ}}(::Type{BSpline{Quadratic{BC}}}, d, pad)
     symix, symixm, symixp = symbol("ix_",d), symbol("ixm_",d), symbol("ixp_",d)
     symx, symfx = symbol("x_",d), symbol("fx_",d)
     pad == 0 || error("Use $BC only with interpolate!")
@@ -83,7 +83,7 @@ function inner_system_diags{T,Q<:Quadratic}(::Type{T}, n::Int, ::Type{Q})
     (dl,d,du)
 end
 
-function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnCell})
+function prefiltering_system{T,TCoefs,BC<:Union{Flat,Reflect}}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnCell})
     dl,d,du = inner_system_diags(T,n,Quadratic{BC})
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
@@ -111,7 +111,7 @@ function prefiltering_system{T,TCoefs}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type
     Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
-function prefiltering_system{T,TCoefs,BC<:Union(Flat,Reflect)}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnGrid})
+function prefiltering_system{T,TCoefs,BC<:Union{Flat,Reflect}}(::Type{T}, ::Type{TCoefs}, n::Int, ::Type{Quadratic{BC}}, ::Type{OnGrid})
     dl,d,du = inner_system_diags(T,n,Quadratic{BC})
     d[1] = d[end] = -1
     du[1] = dl[end] = 0

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -1,5 +1,5 @@
 export Throw,
-       FilledInterpolation   # for direct control over typeof(fillvalue)
+       FilledExtrapolation   # for direct control over typeof(fillvalue)
 
 include("error.jl")
 

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -1,25 +1,25 @@
 nindexes(N::Int) = N == 1 ? "1 index" : "$N indexes"
 
 
-type FilledInterpolation{T,N,ITP<:AbstractInterpolation,IT,GT,FT} <: AbstractExtrapolation{T,N,ITP,IT,GT}
+type FilledExtrapolation{T,N,ITP<:AbstractInterpolation,IT,GT,FT} <: AbstractExtrapolation{T,N,ITP,IT,GT}
     itp::ITP
     fillvalue::FT
 end
 @doc """
-`FilledInterpolation(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
+`FilledExtrapolation(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
 
 By comparison with `extrapolate`, this version lets you control the `fillvalue`'s type directly.  It's important for the `fillvalue` to be of the same type as returned by `itp[x1,x2,...]` for in-bounds regions for the index types you are using; otherwise, indexing will be type-unstable (and slow).
 """ ->
-function FilledInterpolation{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue)
-    FilledInterpolation{T,N,typeof(itp),IT,GT,typeof(fillvalue)}(itp, fillvalue)
+function FilledExtrapolation{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue)
+    FilledExtrapolation{T,N,typeof(itp),IT,GT,typeof(fillvalue)}(itp, fillvalue)
 end
 
 @doc """
 `extrapolate(itp, fillvalue)` creates an extrapolation object that returns the `fillvalue` any time the indexes in `itp[x1,x2,...]` are out-of-bounds.
 """ ->
-extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = FilledInterpolation(itp, convert(eltype(itp), fillvalue))
+extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = FilledExtrapolation(itp, convert(eltype(itp), fillvalue))
 
-@generated function getindex{T,N}(fitp::FilledInterpolation{T,N}, args::Number...)
+@generated function getindex{T,N}(fitp::FilledExtrapolation{T,N}, args::Number...)
     n = length(args)
     n == N || return error("Must index $(N)-dimensional interpolation objects with $(nindexes(N))")
     meta = Expr(:meta, :inline)
@@ -33,4 +33,4 @@ extrapolate{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}, fillvalue) = Fille
     end
 end
 
-getindex{T}(fitp::FilledInterpolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x] : throw(BoundsError())
+getindex{T}(fitp::FilledExtrapolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x] : throw(BoundsError())

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -5,7 +5,7 @@ Gridded{D<:Degree}(::Type{D}) = Gridded{D}
 
 griddedtype{D<:Degree}(::Type{Gridded{D}}) = D
 
-typealias GridIndex{T} Union(AbstractVector{T}, Tuple)
+typealias GridIndex{T} Union{AbstractVector{T}, Tuple}
 
 # Because Ranges check bounds on getindex, it's actually faster to convert the
 # knots to Vectors. It's also good to take a copy, so it doesn't get modified later.

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -27,7 +27,7 @@ etpf = @inferred(extrapolate(itpg, NaN))
 @test_throws BoundsError etpf[2.5,2]
 @test_throws ErrorException etpf[2.5,2,1]  # this will probably become a BoundsError someday
 
-etpf = @inferred(FilledInterpolation(itpg, 'x'))
+etpf = @inferred(FilledExtrapolation(itpg, 'x'))
 @test_approx_eq etpf[2] f(2)
 @test etpf[-1.5] == 'x'
 


### PR DESCRIPTION
When I rebased #47 I put this first, so you can have a say in whether it's a good or bad idea, @timholy. But since this functionality is essentially extrapolation, I think this name is better :)