### PR TITLE
Allow manual override of return type for fillvalue

### DIFF
--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -69,6 +69,15 @@ function gradient_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
     end
 end
 
+function getindex_return_type{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}, argtypes)
+    Tret = TCoefs
+    for a in argtypes
+        Tret = Base.promote_op(Base.MulFun, Tret, a)
+    end
+    Tret
+end
+
+
 @generated function gradient!{T,N}(g::AbstractVector, itp::BSplineInterpolation{T,N}, xs::Number...)
     length(xs) == N || error("Can only be called with $N indexes")
     gradient_impl(itp)

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -1,5 +1,4 @@
-export Throw,
-       FilledExtrapolation   # for direct control over typeof(fillvalue)
+export Throw
 
 type Extrapolation{T,N,ITPT,IT,GT,ET} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
     itp::ITPT

--- a/src/gridded/indexing.jl
+++ b/src/gridded/indexing.jl
@@ -86,3 +86,11 @@ function getindex{T,N,TCoefs,IT<:DimSpec{Gridded},K,P}(itp::GriddedInterpolation
     dest = Array(T, map(length, x))::Array{T,N}
     getindex!(dest, itp, x...)
 end
+
+function getindex_return_type{T,N,TCoefs,IT<:DimSpec{Gridded},K,P}(::Type{GriddedInterpolation{T,N,TCoefs,IT,K,P}}, argtypes)
+    Tret = TCoefs
+    for a in argtypes
+        Tret = Base.promote_op(Base.MulFun, Tret, a)
+    end
+    Tret
+end

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -27,9 +27,7 @@ etpf = @inferred(extrapolate(itpg, NaN))
 @test_throws BoundsError etpf[2.5,2]
 @test_throws ErrorException etpf[2.5,2,1]  # this will probably become a BoundsError someday
 
-etpf = @inferred(FilledExtrapolation(itpg, 'x'))
-@test_approx_eq etpf[2] f(2)
-@test etpf[-1.5] == 'x'
+@test isa(@inferred(getindex(etpf, dual(-2.5,1))), Dual)
 
 etpl = extrapolate(itpg, Linear)
 k_lo = A[2] - A[1]


### PR DESCRIPTION
I'm playing with ForwardDiff as a way of computing gradients, and needed this to handle the fact that sometimes the same `FilledExtrapolation` object gets called with two different types of indexes (`Float64` and `GradientNumber{Float64,...}`). I added these lines (the last one being the relevant one here) to my own code:
```jl
# Some necessary ForwardDiff extensions
Base.real(v::ForwardDiff.GradientNumber) = real(v.value)
Base.ceil(::Type{Int}, v::ForwardDiff.GradientNumber)  = ceil(Int, v.value)
Base.floor(::Type{Int}, v::ForwardDiff.GradientNumber) = floor(Int, v.value)
# Type-stability in gradient computation
@generated function Interpolations.fillvalue{T<:ForwardDiff.GradientNumber}(val, args::T...)
    :(ForwardDiff.GradientNumber(val, args[1].partials.data))
end
```
and now ForwardDiff works fine.