### PR TITLE
De-activate tests dependent on Base.Test.with_handler on 0.5

### DIFF
--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -21,26 +21,31 @@ end
 
 @test length(gradient(sitp, pi/3, 2)) == 1
 
-# Test error messages for incorrect initialization
-function message_is(message)
-	r -> r.err.msg == message || error("Incorrect error message: expected '$message' but was '$(r.err.msg)'")
+if VERSION < v"0.5.0-dev" # Test.with_handler was removed in 0.5
+
+    # Test error messages for incorrect initialization
+    function message_is(message)
+        r -> r.err.msg == message || error("Incorrect error message: expected '$message' but was '$(r.err.msg)'")
+    end
+    Test.with_handler(message_is("Must scale 2-dimensional interpolation object with exactly 2 ranges (you used 1)")) do
+        @test scale(itp, xs)
+    end
+    Test.with_handler(message_is("NoInterp dimension 2 must be scaled with unit range 1:3")) do
+        @test scale(itp, xs, -1:1)
+    end
+    Test.with_handler(message_is("The length of the range in dimension 1 (8) did not equal the size of the interpolation object in that direction (11)")) do
+        @test scale(itp, -pi:2pi/7:pi, 1:3)
+    end
+    Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
+        @test sitp[2.3]
+    end
+    Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
+        @test gradient(sitp, 2.3)
+    end
+    Test.with_handler(message_is("The length of the provided gradient vector (2) did not match the number of interpolating dimensions (1)")) do
+        @test gradient!(Array(Float64, 2), sitp, 2.3, 2)
+    end
+
 end
-Test.with_handler(message_is("Must scale 2-dimensional interpolation object with exactly 2 ranges (you used 1)")) do
-	@test scale(itp, xs)
-end
-Test.with_handler(message_is("NoInterp dimension 2 must be scaled with unit range 1:3")) do
-	@test scale(itp, xs, -1:1)
-end
-Test.with_handler(message_is("The length of the range in dimension 1 (8) did not equal the size of the interpolation object in that direction (11)")) do
-	@test scale(itp, -pi:2pi/7:pi, 1:3)
-end
-Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
-	@test sitp[2.3]
-end
-Test.with_handler(message_is("Must index into 2-dimensional scaled interpolation object with exactly 2 indices (you used 1)")) do
-	@test gradient(sitp, 2.3)
-end
-Test.with_handler(message_is("The length of the provided gradient vector (2) did not match the number of interpolating dimensions (1)")) do
-	@test gradient!(Array(Float64, 2), sitp, 2.3, 2)
-end
+
 end


### PR DESCRIPTION
`Base.Test.with_handler` [was removed](https://github.com/JuliaLang/julia/commit/dc4f1798fe2fa7429e2551caba529cf0b022150d#commitcomment-13390737) in a re-vamp of `Base.Test`.