### PR TITLE
Add an efficient iterator for ScaledInterpolation objects

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -66,8 +66,12 @@ lbounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->lbound(itp,i), N)::NTu
 ubounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->ubound(itp,i), N)::NTuple{N,T}
 lbound{T,N}(itp::AbstractInterpolation{T,N}, d) = convert(T, 1)
 ubound{T,N}(itp::AbstractInterpolation{T,N}, d) = convert(T, size(itp, d))
-itptype{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}) = IT
-gridtype{T,N,IT,GT}(itp::AbstractInterpolation{T,N,IT,GT}) = GT
+itptype{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}}(::Type{AbstractInterpolation{T,N,IT,GT}}) = IT
+itptype{ITP<:AbstractInterpolation}(::Type{ITP}) = itptype(super(ITP))
+itptype(itp::AbstractInterpolation ) = itptype(typeof(itp))
+gridtype{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}}(::Type{AbstractInterpolation{T,N,IT,GT}}) = GT
+gridtype{ITP<:AbstractInterpolation}(::Type{ITP}) = gridtype(super(ITP))
+gridtype(itp::AbstractInterpolation) = gridtype(typeof(itp))
 count_interp_dims{T<:AbstractInterpolation}(::Type{T}, N) = N
 
 @generated function gradient{T,N}(itp::AbstractInterpolation{T,N}, xs...)

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -33,6 +33,8 @@ end
 iextract{T<:BSpline}(::Type{T}, d) = T
 iextract{T<:GridType}(::Type{T}, d) = T
 iextract(t, d) = t.parameters[d]
+padding{T,N,TCoefs,IT,GT,pad}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,pad}}) = pad
+padding(itp::AbstractInterpolation) = padding(typeof(itp))
 padextract(pad::Integer, d) = pad
 padextract(pad::Tuple{Vararg{Integer}}, d) = pad[d]
 

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -1,4 +1,6 @@
-export ScaledInterpolation
+export ScaledInterpolation, eachvalue
+
+import Base: done, next, start
 
 immutable ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
     itp::ITPT
@@ -89,3 +91,166 @@ rescale_gradient(r::UnitRange, g) = g
 
 Implements the chain rule dy/dx = dy/du * du/dx for use when calculating gradients with scaled interpolation objects.
 """ rescale_gradient
+
+
+### Iteration
+type ScaledIterator{CR<:CartesianRange,SITPT,X1,Deg,T}
+    rng::CR
+    sitp::SITPT
+    dx_1::X1
+    nremaining::Int
+    fx_1::X1
+    itp_tail::NTuple{Deg,T}
+end
+
+"""
+`eachvalue(sitp)` constructs an iterator for efficiently visiting each
+grid point of a ScaledInterpolation object in which a small grid is
+being "scaled up" to a larger one.  For example, suppose you have a
+core `BSpline` object defined on a 5x7x4 grid, and you are scaling it
+to a 100x120x20 grid (via `linspace(1,5,100), linspace(1,7,120),
+linspace(1,4,20)`).  You can perform interpolation at each of these
+grid points via
+
+```
+    function foo!(dest, sitp)
+        i = 0
+        for s in eachvalue(sitp)
+            dest[i+=1] = s
+        end
+        dest
+    end
+```
+
+which should be more efficient than
+
+```
+    function bar!(dest, sitp)
+        for I in CartesianRange(size(dest))
+            dest[I] = sitp[I]
+        end
+        dest
+    end
+```
+"""
+@generated function eachvalue{T,N}(sitp::ScaledInterpolation{T,N})
+    ITPT = basetype(sitp)
+    IT = itptype(ITPT)
+    itp_tail = ntuple(i->zero(getindex_return_type(ITPT, ntuple(i->Int, N-1))), nelements(bsplinetype(iextract(IT, 1))))
+    quote
+        dx_1 = coordlookup(sitp.ranges[1], 2) - coordlookup(sitp.ranges[1], 1)
+        ScaledIterator(CartesianRange(ssize(sitp)), sitp, dx_1, 0, zero(dx_1), $itp_tail)
+    end
+end
+
+start(iter::ScaledIterator) = start(iter.rng)
+done(iter::ScaledIterator, state) = done(iter.rng, state)
+
+@generated function next{CR,ITPT,N}(iter::ScaledIterator{CR,ITPT}, state::CartesianIndex{N})
+    value_expr = next_gen(iter)
+    quote
+        $value_expr
+        (value, next(iter.rng, state)[2])
+    end
+end
+
+ssize{T,N}(sitp::ScaledInterpolation{T,N}) = map(r->round(Int, last(r)-first(r)+1), sitp.ranges)::NTuple{N,Int}
+
+nelements(::Union{Type{NoInterp},Type{Constant}}) = 1
+nelements(::Type{Linear}) = 2
+nelements{Q<:Quadratic}(::Type{Q}) = 3
+
+function next_gen{CR,SITPT,X1,Deg,T}(::Type{ScaledIterator{CR,SITPT,X1,Deg,T}})
+    N = ndims(CR)
+    ITPT = basetype(SITPT)
+    IT = itptype(ITPT)
+    BS1 = iextract(IT, 1)
+    BS1 == NoInterp && error("eachvalue is not implemented (and does not make sense) for NoInterp along the first dimension")
+    pad = padding(ITPT)
+    x_syms = [symbol("x_", i) for i = 1:N]
+    interp_index(IT, i) = iextract(IT, i) != NoInterp ?
+        :($(x_syms[i]) = coordlookup(sitp.ranges[$i], state[$i])) :
+        :($(x_syms[i]) = state[$i])
+    # Calculations for the first dimension
+    interp_index1 = interp_index(IT, 1)
+    indices1 = define_indices_d(BS1, 1, padextract(pad, 1))
+    coefexprs1 = coefficients(BS1, N, 1)
+    nremaining_expr = nremaining_gen(BS1)
+    # Calculations for the rest of the dimensions
+    interp_indices_tail = map(i -> interp_index(IT, i), 2:N)
+    indices_tail = [define_indices_d(iextract(IT, i), i, padextract(pad, i)) for i = 2:N]
+    coefexprs_tail = [coefficients(iextract(IT, i), N, i) for i = 2:N]
+    value_exprs_tail = index_gen_tail(BS1, IT, N)
+    quote
+        sitp = iter.sitp
+        itp = sitp.itp
+        if iter.nremaining > 0
+            iter.nremaining -= 1
+            iter.fx_1 += iter.dx_1
+        else
+            range1 = sitp.ranges[1]
+            $interp_index1
+            $indices1
+            iter.nremaining = $nremaining_expr
+            iter.fx_1 = fx_1
+            $(interp_indices_tail...)
+            $(indices_tail...)
+            $(coefexprs_tail...)
+            @inbounds iter.itp_tail = ($(value_exprs_tail...),)
+        end
+        fx_1 = iter.fx_1
+        $coefexprs1
+        $(index_gen1(BS1))
+    end
+end
+
+function index_gen1(::Union{Type{NoInterp}, Type{BSpline{Constant}}})
+    quote
+        value = iter.itp_tail[1]
+    end
+end
+
+function index_gen1(::Type{BSpline{Linear}})
+    quote
+        p = iter.itp_tail
+        value = c_1*p[1] + cp_1*p[2]
+    end
+end
+
+function index_gen1{Q<:Quadratic}(::Type{BSpline{Q}})
+    quote
+        p = iter.itp_tail
+        value = cm_1*p[1] + c_1*p[2] + cp_1*p[3]
+    end
+end
+
+
+function index_gen_tail{IT}(B::Union{Type{NoInterp}, Type{BSpline{Constant}}}, ::Type{IT}, N)
+    [index_gen(B, IT, N, 0)]
+end
+
+function index_gen_tail{IT}(::Type{BSpline{Linear}}, ::Type{IT}, N)
+    [index_gen(BS1, IT, N, i) for i = 0:1]
+end
+
+function index_gen_tail{IT,Q<:Quadratic}(::Type{BSpline{Q}}, ::Type{IT}, N)
+    [index_gen(BSpline{Q}, IT, N, i) for i = -1:1]
+end
+
+function nremaining_gen{Q<:Quadratic}(::Union{Type{BSpline{Constant}}, Type{BSpline{Q}}})
+    quote
+        EPS = 0.001*iter.dx_1
+        floor(Int, iter.dx_1 >= 0 ?
+              (min(length(range1)+EPS, round(Int,x_1) + 0.5) - x_1)/iter.dx_1 :
+              (max(1-EPS, round(Int,x_1) - 0.5) - x_1)/iter.dx_1)
+    end
+end
+
+function nremaining_gen(::Type{BSpline{Linear}})
+    quote
+        EPS = 0.001*iter.dx_1
+        floor(Int, iter.dx_1 >= 0 ?
+              (min(length(range1)+EPS, floor(Int,x_1) + 1) - x_1)/iter.dx_1 :
+              (max(1-EPS, floor(Int,x_1)) - x_1)/iter.dx_1)
+    end
+end

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -1,6 +1,6 @@
 export ScaledInterpolation
 
-type ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
+immutable ScaledInterpolation{T,N,ITPT,IT,GT,RT} <: AbstractInterpolationWrapper{T,N,ITPT,IT,GT}
     itp::ITPT
     ranges::RT
 end


### PR DESCRIPTION
One frequent use for interpolation is to represent a quantity on a "coarse" grid and then construct an array (or perform a computation) in which the object is sampled on a finer grid. In this case, grid points are visited in a predictable sequence, and it turns out we can exploit that predictability to substantially improve the efficiency of interpolation. In the case where the fine grid is much finer than the coarse grid, the cost of the computation goes from `O(3^N)` (in the case of `Quadratic` interpolation) to `O(3)`. Especially for larger `N`, this is a very substantial savings.

The key idea is the following: suppose our coarse grid is 3xMxN, and we're interpolating up to a 201xMxN grid. That means the middle 100 points all correspond, via `coordlookup` on the coarser grid, to an interval `(1.5,2.5)`, i.e., we have 100 points in a row that have constant `ix_1, ix_2, ix_3` values. Since interpolation looks like this:

```jl
   cm_1 * pm + c_1 * p + cp_1 * pp
```
where `pm`, `p`, and `pp` are "partial" results on the trailing dimensions (dimensions 2 and 3), we can compute these partials and then reuse them for all 100 interpolations.

In practice, using the test added here:

```jl
# This one uses the iterator
julia> @time foo!(rfoo, sitp);
  0.145194 seconds (9 allocations: 400 bytes)

# This one uses classic sitp[I] evaluation
julia> @time bar!(rfoo, sitp);
  0.581928 seconds (4 allocations: 160 bytes)
```
so we get an approximate 4-fold speed improvement in 3d (which is huge, although 9-fold would have been even better :wink:).

One note: in the help text and test, `foo!` is written

```jl
    function foo!(dest, sitp)
        i = 0
        for s in eachvalue(sitp)
            dest[i+=1] = s
        end
        dest
    end
```
but this assumes fast linear indexing of `dest`. Ideally it should be written as

```jl
    function foo!(dest, sitp)
        for (I,s) in zip(eachindex(dest), eachvalue(sitp))
            dest[I] = s
        end
        dest
    end
```
but that turns out to perform poorly due to a type-inference failure. I suspect we're running up against the built-in limits of recursion depth in type inference, i.e, we're getting to the point of having such deep layers of `A{B{C{D...}}}` that `inference.jl` is deciding to punt. We should either look into bumping these limits another notch, or we'll have to start being very careful about adding yet more layers of wrapper-types. In particular, while I haven't tested yet I fear that this may behave badly for `Extrapolation` types simply because they add one extra layer.
