### PR TITLE
Enable gradient method for Gridded(Constant()) and Gridded(Linear())

### DIFF
--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -183,4 +183,25 @@ function prefiltering_system{T,TCoefs,GT<:GridType}(::Type{T}, ::Type{TCoefs}, n
     Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TCoefs, n)
 end
 
+
+"""
+    prefiltering_system{T,TCoefs,GT<:GridType,D<:Degree}m(::T, ::Type{TCoefs}, n::Int, ::Type{D}, ::Type{GT})
+
+Given type information for the data (`T`, `TCoefs`) and interpolation scheme
+(`GT`, `D`) as well the number of rows in the data input (`n`), compute the
+system used to prefilter spline coefficients
+
+For quadratic and cubic splines this system is tridagonal for all interior rows.
+
+Boundary conditions determine the number of non zero elements on the first
+and last rows. Some of these boundary conditions require that these rows have
+off tri-diagonal elements (e.g the `[1,3]` element of the matrix).
+
+To maintain the efficiency of using solving tridiagonal systems, the
+[Woodbury matrix identity](https://en.wikipedia.org/wiki/Woodbury_matrix_identity)
+is used to add additional elements off the main 3 diagonals.
+"""
+prefiltering_system
+
+
 sqr(x) = x*x

--- a/src/gridded/constant.jl
+++ b/src/gridded/constant.jl
@@ -15,6 +15,11 @@ function coefficients(::Type{Gridded{Constant}}, N, d)
     :($sym = 1)
 end
 
+function gradient_coefficients(::Type{Gridded{Constant}}, N, d)
+    sym, symx = symbol("c_",d), symbol("x_",d)
+    :($sym = 0)
+end
+
 function index_gen{IT<:DimSpec{Gridded}}(::Type{Gridded{Constant}}, ::Type{IT}, N::Integer, offsets...)
     if (length(offsets) < N)
         d = length(offsets)+1

--- a/src/gridded/linear.jl
+++ b/src/gridded/linear.jl
@@ -18,6 +18,16 @@ function coefficients(::Type{Gridded{Linear}}, N, d)
     end
 end
 
+function gradient_coefficients(::Type{Gridded{Linear}}, d)
+    sym, symp = symbol("c_",d), symbol("cp_",d)
+    symk, symix = symbol("k_",d), symbol("ix_",d)
+    symixp = symbol("ixp_",d)
+    quote
+        $symp = 1/($symk[$symixp] - $symk[$symix])
+        $sym = - $symp
+    end
+end
+
 # This assumes fractional values 0 <= fx_d <= 1, integral values ix_d and ixp_d (typically ixp_d = ix_d+1,
 #except at boundaries), and an array itp.coefs
 function index_gen{IT<:DimSpec{Gridded}}(::Type{Gridded{Linear}}, ::Type{IT}, N::Integer, offsets...)


### PR DESCRIPTION
This was mostly an exercise to confirm that I understand how all the meta-programming fits together.

One thing I don't like is that when I tested the gradient on a non 1-spaced grid I had to raise the multiplicative factor on the "equality tolerance" from 0.1 to 0.5. Does this bother anyone else or suggest I have made a mistake somewhere?

