### PR TITLE
speed up size, lbounds, and ubounds with @generated functions

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -68,12 +68,12 @@ immutable InPlace <: Flag end
 immutable InPlaceQ <: Flag end
 typealias Natural Line
 
-size{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->size(itp,i), Val{N})
+@generated size{T, N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(size(itp, $i)) for i in 1:N]...)
 size(exp::AbstractExtrapolation, d) = size(exp.itp, d)
 bounds{T,N}(itp::AbstractInterpolation{T,N}) = tuple(zip(lbounds(itp), ubounds(itp))...)
 bounds{T,N}(itp::AbstractInterpolation{T,N}, d) = (lbound(itp,d),ubound(itp,d))
-lbounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->lbound(itp,i), Val{N})
-ubounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->ubound(itp,i), Val{N})
+@generated lbounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(lbound(itp, $i)) for i in 1:N]...)
+@generated ubounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(ubound(itp, $i)) for i in 1:N]...)
 lbound{T,N}(itp::AbstractInterpolation{T,N}, d) = 1
 ubound{T,N}(itp::AbstractInterpolation{T,N}, d) = size(itp, d)
 itptype{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}}(::Type{AbstractInterpolation{T,N,IT,GT}}) = IT

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -68,13 +68,12 @@ immutable InPlace <: Flag end
 immutable InPlaceQ <: Flag end
 typealias Natural Line
 
-# TODO: size might have to be faster?
-size{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->size(itp,i), N)::NTuple{N,Int}
+@generated size{T, N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(size(itp, $i)) for i in 1:N]...)
 size(exp::AbstractExtrapolation, d) = size(exp.itp, d)
 bounds{T,N}(itp::AbstractInterpolation{T,N}) = tuple(zip(lbounds(itp), ubounds(itp))...)
 bounds{T,N}(itp::AbstractInterpolation{T,N}, d) = (lbound(itp,d),ubound(itp,d))
-lbounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->lbound(itp,i), N)::NTuple{N,T}
-ubounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->ubound(itp,i), N)::NTuple{N,T}
+@generated lbounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(lbound(itp, $i)) for i in 1:N]...)
+@generated ubounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(ubound(itp, $i)) for i in 1:N]...)
 lbound{T,N}(itp::AbstractInterpolation{T,N}, d) = 1
 ubound{T,N}(itp::AbstractInterpolation{T,N}, d) = size(itp, d)
 itptype{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}}(::Type{AbstractInterpolation{T,N,IT,GT}}) = IT

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -68,12 +68,12 @@ immutable InPlace <: Flag end
 immutable InPlaceQ <: Flag end
 typealias Natural Line
 
-@generated size{T, N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(size(itp, $i)) for i in 1:N]...)
+size{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->size(itp,i), Val{N})
 size(exp::AbstractExtrapolation, d) = size(exp.itp, d)
 bounds{T,N}(itp::AbstractInterpolation{T,N}) = tuple(zip(lbounds(itp), ubounds(itp))...)
 bounds{T,N}(itp::AbstractInterpolation{T,N}, d) = (lbound(itp,d),ubound(itp,d))
-@generated lbounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(lbound(itp, $i)) for i in 1:N]...)
-@generated ubounds{T,N}(itp::AbstractInterpolation{T,N}) = Expr(:tuple, [:(ubound(itp, $i)) for i in 1:N]...)
+lbounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->lbound(itp,i), Val{N})
+ubounds{T,N}(itp::AbstractInterpolation{T,N}) = ntuple(i->ubound(itp,i), Val{N})
 lbound{T,N}(itp::AbstractInterpolation{T,N}, d) = 1
 ubound{T,N}(itp::AbstractInterpolation{T,N}, d) = size(itp, d)
 itptype{T,N,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType}}(::Type{AbstractInterpolation{T,N,IT,GT}}) = IT


### PR DESCRIPTION
`size()`, `lbounds()`, and `ubounds()` currently use the `ntuple(i -> f(i), N)` syntax, which is rather slow. A generated function makes the return type inferable without any type assertions and also improves performance. It also has the side-effect of fixing an apparent typeassert bug in `lbounds` and `ubounds`. 

## Before

```julia
julia> using BenchmarkTools

julia> A = rand(2,2,2)
2×2×2 Array{Float64,3}:
[:, :, 1] =
 0.771663  0.124192
 0.524341  0.676021

[:, :, 2] =
 0.295365  0.966051
 0.585499  0.599789

julia> itp = interpolate(A, BSpline(Linear()), OnGrid())
2×2×2 Interpolations.BSplineInterpolation{Float64,3,Array{Float64,3},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,0}:
[:, :, 1] =
 0.771663  0.124192
 0.524341  0.676021

[:, :, 2] =
 0.295365  0.966051
 0.585499  0.599789

julia> @benchmark size($itp)
BenchmarkTools.Trial:
  memory estimate:  48.00 bytes
  allocs estimate:  2
  --------------
  minimum time:     75.793 ns (0.00% GC)
  median time:      78.353 ns (0.00% GC)
  mean time:        90.578 ns (3.68% GC)
  maximum time:     3.053 μs (93.58% GC)
  --------------
  samples:          10000
  evals/sample:     970
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark Interpolations.lbounds($itp)
ERROR: TypeError: typeassert: expected Tuple{Float64,Float64,Float64}, got Tuple{Int64,Int64,Int64}
 in ##core#280() at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:250
 in ##sample#281(::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:257
 in #_run#2(::Bool, ::String, ::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#279")}, ::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:285
 in (::BenchmarkTools.#kw##_run)(::Array{Any,1}, ::BenchmarkTools.#_run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#279")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 in anonymous at ./<missing>:?
 in #run#17(::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#279")}, ::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:32
 in (::Base.#kw##run)(::Array{Any,1}, ::Base.#run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#279")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 in warmup(::BenchmarkTools.Benchmark{Symbol("##benchmark#279")}) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:67

julia> @benchmark Interpolations.ubounds($itp)
ERROR: TypeError: typeassert: expected Tuple{Float64,Float64,Float64}, got Tuple{Int64,Int64,Int64}
 in ##core#284() at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:250
 in ##sample#285(::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:257
 in #_run#3(::Bool, ::String, ::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#283")}, ::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:285
 in (::BenchmarkTools.#kw##_run)(::Array{Any,1}, ::BenchmarkTools.#_run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#283")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 in anonymous at ./<missing>:?
 in #run#17(::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#283")}, ::BenchmarkTools.Parameters) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:32
 in (::Base.#kw##run)(::Array{Any,1}, ::Base.#run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#283")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 in warmup(::BenchmarkTools.Benchmark{Symbol("##benchmark#283")}) at /Users/rdeits/.julia/v0.5/BenchmarkTools/src/execution.jl:67
```

## After

```julia
julia> using BenchmarkTools

julia> A = rand(2,2,2);

julia> itp = interpolate(A, BSpline(Linear()), OnGrid());

julia> @benchmark size($itp)
BenchmarkTools.Trial:
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     3.691 ns (0.00% GC)
  median time:      3.752 ns (0.00% GC)
  mean time:        3.836 ns (0.00% GC)
  maximum time:     16.309 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark Interpolations.lbounds($itp)
BenchmarkTools.Trial:
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.695 ns (0.00% GC)
  median time:      1.739 ns (0.00% GC)
  mean time:        1.785 ns (0.00% GC)
  maximum time:     24.235 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark Interpolations.ubounds($itp)
BenchmarkTools.Trial:
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     5.964 ns (0.00% GC)
  median time:      5.989 ns (0.00% GC)
  mean time:        6.923 ns (0.00% GC)
  maximum time:     41.035 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
  time tolerance:   5.00%
  memory tolerance: 1.00%
```