### PR TITLE
Minor but useful correction of formatting of the documentation.

### DIFF
--- a/docs/src/convenience-construction.md
+++ b/docs/src/convenience-construction.md
@@ -5,16 +5,16 @@ For constant, linear, and cubic spline interpolations, `ConstantInterpolation`, 
 can be used to create interpolating and extrapolating objects handily.
 
 ### Motivating Example
-By using the convenience constructor one can simplify expressions. For example, the creation of an interpolation object 
+By using the convenience constructor one can simplify expressions. For example, the creation of an interpolation object
 ```julia
 extrap_full = extrapolate(scale(interpolate(A, BSpline(Linear())), xs), Line())
 ```
 can be written as the more readable
 ```julia
 extrap = LinearInterpolation(xs, A, extrapolation_bc = Line())
- ```
+```
  by using the convenience constructor.
- 
+
  ### Usage
 
 ```julia


### PR DESCRIPTION
Removed (apparently unintended) indentation of the closing triple ticks in order to correct the screwed documentation rendering.

In particular, the problem was with the page https://github.com/JuliaMath/Interpolations.jl/blob/master/docs/src/convenience-construction.md. When viewed as a markdown, everything seems fine, but when a documentation page is generated from it http://juliamath.github.io/Interpolations.jl/latest/convenience-construction/, it is screwed (see how the `### Usage` is in the code block and the subsequent code is rendered as a text).