### PR TITLE
Make indexing by non-integers an error

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,4 +1,8 @@
 # Removed with 0.16, indexing via non-integers
+getindex(itp::AbstractInterpolation{T,N}, i::Vararg{Number,N}) where {T,N} =
+    error("Indexing an AbstractInterpolation by non-integers is no longer supported in Interpolations.jl since v0.16. Use the function calling interface instead: `itp(i...)`.")
+getindex(itp::AbstractInterpolation{T,N}, i::Vararg{ExpandedIndexTypes,N}) where {T,N} =
+    error("Indexing an AbstractInterpolation by non-integers is no longer supported in Interpolations.jl since v0.16. Use the function calling interface instead: `itp(i...)`.")
 
 for T in (:Throw, :Flat, :Line, :Free, :Periodic, :Reflect, :InPlace, :InPlaceQ)
     @eval begin

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -177,4 +177,10 @@ using Interpolations, Test, ForwardDiff
         t = -3.0:0.01:3.0
         @test itp_cdf.(t) isa Vector{Float64}
     end
+    @testset "issue 630" begin
+        itp = interpolate(ones(100,100), BSpline(Linear()));
+        # Indexing by non-integers should not result in a StackOverflow due to `Base.to_index(::AbstractInterpolation, x::Number) = x`
+        @test_throws "Indexing an AbstractInterpolation by non-integers is no longer supported" itp[2.2, 33.3]
+        @test_throws "Indexing an AbstractInterpolation by non-integers is no longer supported" itp[2.2, 2.0:5.0]
+    end
 end


### PR DESCRIPTION
Fix #630 

Indexing by non-integers was deprecated in #226 in the year 2018 with v0.9 and removed in https://github.com/JuliaMath/Interpolations.jl/pull/579 in the year 2025 with v0.16. However, removal of the deprecation results in a `StackOverflow` as per #630.

The immediate fix is to re-add the methods but have them result in an error providing guidance on how to modify the deprecated behavior.

In the longer term, the custom `Base.to_index` needs to be removed.
https://github.com/JuliaMath/Interpolations.jl/blob/7a2d581387b162601e1216c8e11338b55409085f/src/Interpolations.jl#L378
Consequently, we should also not use `to_indices` to process arguments when using the function calling interface. This change is significantly more involved and may result in further breakage. For example, it is not clear if the function calling interface should support `CartesianIndex` as an argument or not.

The MWE in #630 now results in the following error.
```julia-repl
julia> using Interpolations

julia> itp = interpolate(ones(100,100), BSpline(Linear()));

julia> r = itp[2.2, 33.3]
ERROR: Indexing an AbstractInterpolation by non-integers is no longer supported in Interpolations.jl since v0.16. Use the function calling interface instead: `itp(i...)`.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] getindex(::Interpolations.BSplineInterpolation{Float64, 2, Matrix{Float64}, BSpline{Linear{Throw{OnGrid}}}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}, ::Float64, ::Float64)
   @ Interpolations ~/.julia/dev/Interpolations/src/deprecations.jl:2
 [3] top-level scope
   @ REPL[3]:1
```
