### PR TITLE
WIP: reduced precision for lanczos_opencv

### DIFF
--- a/src/lanczos/lanczos_opencv.jl
+++ b/src/lanczos/lanczos_opencv.jl
@@ -54,7 +54,8 @@ struct Lanczos4OpenCV <: AbstractLanczos end
 
 degree(::Lanczos4OpenCV) = 4
 
-value_weights(::Lanczos4OpenCV, δx) = _lanczos4_opencv(δx)
+value_weights(::Lanczos4OpenCV, δx::T) where {T} =
+        _lanczos4_opencv(float(T), float(T).(l4_2d_cs), δx)
 
 # s45 = sqrt(2)/2
 const s45 = 0.70710678118654752440084436210485
@@ -65,8 +66,7 @@ const s45 = 0.70710678118654752440084436210485
 const l4_2d_cs = SA[1 0; -s45 -s45; 0 1; s45 -s45; -1 0; s45 s45; 0 -1; -s45 s45]
 
 
-function _lanczos4_opencv(δx::T) where T
-    F = float(T)
+function _lanczos4_opencv(::Type{F}, l4_2d_cs, δx) where {F}
     p_4 = π / F(4)
     y0 = -(δx + 3) * p_4
     s0::F, c0::F = sincos(y0)

--- a/src/lanczos/lanczos_opencv.jl
+++ b/src/lanczos/lanczos_opencv.jl
@@ -65,20 +65,21 @@ const s45 = 0.70710678118654752440084436210485
 const l4_2d_cs = SA[1 0; -s45 -s45; 0 1; s45 -s45; -1 0; s45 s45; 0 -1; -s45 s45]
 
 
-function _lanczos4_opencv(δx)
-    p_4 = π / 4
+function _lanczos4_opencv(δx::T) where T
+    F = float(T)
+    p_4 = π / F(4)
     y0 = -(δx + 3) * p_4
-    s0, c0 = sincos(y0)
+    s0::F, c0::F = sincos(y0)
     cs = ntuple(8) do i
         y = (δx + 4 - i) * p_4
         # Improve precision of Lanczos OpenCV4 #451, avoid NaN
         if iszero(y)
-            y = eps(oneunit(y))/8
+            y = eps(oneunit(y))/F(8)
         end
         # Numerator is the sin subtraction identity
         # It is equivalent to the following
         # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
-        (l4_2d_cs[i, 1] * s0 + l4_2d_cs[i, 2] * c0) / y^2
+        (F(l4_2d_cs[i, 1]) * s0 + F(l4_2d_cs[i, 2]) * c0) / y^2
     end
     sum_cs = sum(cs)
     normed_cs = ntuple(i -> cs[i] / sum_cs, Val(8))

--- a/src/lanczos/lanczos_opencv.jl
+++ b/src/lanczos/lanczos_opencv.jl
@@ -50,11 +50,12 @@ export Lanczos4OpenCV
 Alternative implementation of Lanczos resampling using algorithm `lanczos4` function of OpenCV:
 https://github.com/opencv/opencv/blob/de15636724967faf62c2d1bce26f4335e4b359e5/modules/imgproc/src/resize.cpp#L917-L946
 """
-struct Lanczos4OpenCV <: AbstractLanczos end
+struct Lanczos4OpenCV{T} <: AbstractLanczos end
+Lanczos4OpenCV() = Lanczos4OpenCV{Float64}()
 
 degree(::Lanczos4OpenCV) = 4
 
-value_weights(::Lanczos4OpenCV, δx::T) where {T} =
+value_weights(::Lanczos4OpenCV{T}, δx) where {T} =
         _lanczos4_opencv(float(T), float(T).(l4_2d_cs), δx)
 
 # s45 = sqrt(2)/2

--- a/src/lanczos/lanczos_opencv.jl
+++ b/src/lanczos/lanczos_opencv.jl
@@ -68,19 +68,17 @@ const l4_2d_cs = SA[1 0; -s45 -s45; 0 1; s45 -s45; -1 0; s45 s45; 0 -1; -s45 s45
 
 
 function _lanczos4_opencv(::Type{F}, l4_2d_cs, δx) where {F}
-    p_4 = π / F(4)
-    y0 = -(δx + 3) * p_4
-    s0::F, c0::F = sincos(y0)
+    p_4 = π * F(0.25)
+    y0 = -(δx + F(3)) * p_4
+    s0, c0 = sincos(y0)
     cs = ntuple(8) do i
-        y = (δx + 4 - i) * p_4
-        # Improve precision of Lanczos OpenCV4 #451, avoid NaN
-        if iszero(y)
-            y = eps(oneunit(y))/F(8)
+        y = δx + 4 - i
+        if abs(y) >= F(1e-6)
+            y *= p_4
+            (F(l4_2d_cs[i, 1]) * s0 + F(l4_2d_cs[i, 2]) * c0) / y^2
+        else
+            F(1e30)
         end
-        # Numerator is the sin subtraction identity
-        # It is equivalent to the following
-        # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
-        (F(l4_2d_cs[i, 1]) * s0 + F(l4_2d_cs[i, 2]) * c0) / y^2
     end
     sum_cs = sum(cs)
     normed_cs = ntuple(i -> cs[i] / sum_cs, Val(8))

--- a/src/lanczos/lanczos_opencv.jl
+++ b/src/lanczos/lanczos_opencv.jl
@@ -42,21 +42,7 @@ the use of this software, even if advised of the possibility of such damage.
 =#
 using StaticArrays
 
-export Lanczos4OpenCV
-
-"""
-    Lanczos4OpenCV()
-
-Alternative implementation of Lanczos resampling using algorithm `lanczos4` function of OpenCV:
-https://github.com/opencv/opencv/blob/de15636724967faf62c2d1bce26f4335e4b359e5/modules/imgproc/src/resize.cpp#L917-L946
-"""
-struct Lanczos4OpenCV{T} <: AbstractLanczos end
-Lanczos4OpenCV() = Lanczos4OpenCV{Float64}()
-
-degree(::Lanczos4OpenCV) = 4
-
-value_weights(::Lanczos4OpenCV{T}, δx) where {T} =
-        _lanczos4_opencv(float(T), float(T).(l4_2d_cs), δx)
+export Lanczos4OpenCV, Lanczos4OpenCVFaithful
 
 # s45 = sqrt(2)/2
 const s45 = 0.70710678118654752440084436210485
@@ -67,7 +53,68 @@ const s45 = 0.70710678118654752440084436210485
 const l4_2d_cs = SA[1 0; -s45 -s45; 0 1; s45 -s45; -1 0; s45 s45; 0 -1; -s45 s45]
 
 
-function _lanczos4_opencv(::Type{F}, l4_2d_cs, δx) where {F}
+"""
+    Lanczos4OpenCV()
+
+Alternative implementation of Lanczos resampling using algorithm `lanczos4`
+function of OpenCV:
+
+https://github.com/opencv/opencv/blob/de15636724967faf62c2d1bce26f4335e4b359e5/modules/imgproc/src/resize.cpp#L917-L946
+
+If your data are Float32, consider using `Lanczos4OpenCVFaithful` instead.
+"""
+struct Lanczos4OpenCV <: AbstractLanczos end
+
+degree(::Lanczos4OpenCV) = 4
+
+value_weights(::Lanczos4OpenCV, δx) = _lanczos4_opencv(δx)
+
+# a simple refactoring of `_lanczos4_opencv` to use Float32 throughout results
+# in s0 == c0 and so the numerator of cs[4] is 0 as is normed_cs[4] (when it
+# should be 1)
+
+function _lanczos4_opencv(δx)
+    p_4 = π / 4
+    y0 = -(δx + 3) * p_4
+    s0, c0 = sincos(y0)
+    cs = ntuple(8) do i
+        y = (δx + 4 - i) * p_4
+        # Improve precision of Lanczos OpenCV4 #451, avoid NaN
+        if iszero(y)
+            y = eps(oneunit(y))/8
+        end
+        # Numerator is the sin subtraction identity
+        # It is equivalent to the following
+        # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
+        (l4_2d_cs[i, 1] * s0 + l4_2d_cs[i, 2] * c0) / y^2
+    end
+    sum_cs = sum(cs)
+    normed_cs = ntuple(i -> cs[i] / sum_cs, Val(8))
+    return normed_cs
+end
+
+
+"""
+    Lanczos4OpenCVFaithful{T}()
+
+Similar to Lanczos4OpenCV(), but mirrors the calculations more closely to
+reduce numerical discrepancies with the OpenCV implementation, and supports
+reduced precision (e.g. Float32, the default).
+"""
+struct Lanczos4OpenCVFaithful{T} <: AbstractLanczos end
+Lanczos4OpenCVFaithful() = Lanczos4OpenCVFaithful{Float32}()
+
+degree(::Lanczos4OpenCVFaithful) = 4
+
+value_weights(::Lanczos4OpenCVFaithful{T}, δx) where {T} =
+        _lanczos4_opencv_faithful(float(T), float(T).(l4_2d_cs), δx)
+
+# main differences with `_lanczos4_opencv` are (1) the criterion for preventing a
+# division by zero is `< pi/4 * 1e-6` (instead of `iszero`) and (2) the resulting
+# coefficient is replaced with `1e30` (instead of using `(eps()/8)^2` in the
+# denominator)
+
+function _lanczos4_opencv_faithful(::Type{F}, l4_2d_cs, δx) where {F}
     p_4 = π * F(0.25)
     y0 = -(δx + F(3)) * p_4
     s0, c0 = sincos(y0)

--- a/test/lanczos/runtests.jl
+++ b/test/lanczos/runtests.jl
@@ -61,9 +61,12 @@ end
 end
 
 @testset "Lanczos OpenCV4 Faithful" begin
-    @test 1f0 == Interpolations._lanczos4_opencv_faithful(Float32, Interpolations.l4_2d_cs, 0.0f0)[4]
-    @test 1.0 == Interpolations._lanczos4_opencv_faithful(Float64, Interpolations.l4_2d_cs, 0.0)[4]
-    @test 1.0 == Interpolations._lanczos4_opencv(0.0)[4]
+    idx = Interpolations.degree(Lanczos4OpenCVFaithful{Float32}())
+    @test 1f0 == Interpolations.value_weights(Lanczos4OpenCVFaithful{Float32}(), 0.0f0)[idx]
+    idx = Interpolations.degree(Lanczos4OpenCVFaithful{Float64}())
+    @test 1.0 == Interpolations.value_weights(Lanczos4OpenCVFaithful{Float64}(), 0.0)[idx]
+    idx = Interpolations.degree(Lanczos4OpenCV())
+    @test 1.0 == Interpolations.value_weights(Lanczos4OpenCV(), 0.0)[idx]
     # were _lanczos4_opencv to be refactored to use Float32 throughout,
     # the 4th element returned would be 0.0
 end

--- a/test/lanczos/runtests.jl
+++ b/test/lanczos/runtests.jl
@@ -28,11 +28,9 @@ using Interpolations: degree,
     @test 1 < itp(1.5) < 2
     @test 99 < itp(99.5) < 100
 
-
     # symmetry check
     interpolant = itp.(X)
     @test interpolant ≈ reverse(interpolant)
-
 end
 
 @testset "Lanczos OpenCV4" begin
@@ -60,7 +58,14 @@ end
     # symmetry check
     interpolant = itp.(X)
     @test interpolant ≈ reverse(interpolant)
+end
 
+@testset "Lanczos OpenCV4 Faithful" begin
+    @test 1f0 == Interpolations._lanczos4_opencv_faithful(Float32, Interpolations.l4_2d_cs, 0.0f0)[4]
+    @test 1.0 == Interpolations._lanczos4_opencv_faithful(Float64, Interpolations.l4_2d_cs, 0.0)[4]
+    @test 1.0 == Interpolations._lanczos4_opencv(0.0)[4]
+    # were _lanczos4_opencv to be refactored to use Float32 throughout,
+    # the 4th element returned would be 0.0
 end
 
 end


### PR DESCRIPTION
using Float32 for Lanczos is ~2x faster and uses ~1/2x as much memory as the current Float64.

this PR currently uses whatever precision was input as the precision the internal calculations are performed with.  i could also imagine specifying the type used for internal computations in the type (e.g. `struct Lanczos4OpenCV{T} <: AbstractLanczos end`) to separate it from the input.

i'm also curious where there is a more clever way to cast `l4_2d_cs` at compile time so as not to incur runtime penalities.

let me know what you think and i'll add some tests and docs.

```
julia> using Interpolations, BenchmarkTools

julia> x=rand(1_000_000);

julia> @benchmark Interpolations._lanczos4_opencv.(x)
BenchmarkTools.Trial: 231 samples with 1 evaluation per sample.
 Range (min … max):  19.061 ms … 83.561 ms  ┊ GC (min … max): 5.34% … 74.95%
 Time  (median):     21.303 ms              ┊ GC (median):    2.90%
 Time  (mean ± σ):   21.654 ms ±  4.135 ms  ┊ GC (mean ± σ):  4.35% ±  5.10%

                       ▅█▄▃                                    
  ▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▃▃▃▃▅▇█████▄▄▄▃▃▃▃▂▂▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▂ ▃
  19.1 ms         Histogram: frequency by time        24.8 ms <

 Memory estimate: 61.05 MiB, allocs estimate: 4.

julia> x=rand(Float32, 1_000_000);

julia> @benchmark Interpolations._lanczos4_opencv.(x)
BenchmarkTools.Trial: 387 samples with 1 evaluation per sample.
 Range (min … max):  12.078 ms … 76.608 ms  ┊ GC (min … max): 0.00% … 83.87%
 Time  (median):     12.695 ms              ┊ GC (median):    3.05%
 Time  (mean ± σ):   12.928 ms ±  3.290 ms  ┊ GC (mean ± σ):  4.56% ±  4.80%

     ▂       ▄▅▇██▇▅▂                                          
  ▆▇▇██▄▆▆▄▇██████████▄█▄▇▄▆▁▄▁▇▄▄▁▄▄▄▇▄▆▁▁▄▁▁▁▁▆▁▁▁▁▁▁▄▄▁▁▁▄ ▇
  12.1 ms      Histogram: log(frequency) by time      14.5 ms <

 Memory estimate: 30.53 MiB, allocs estimate: 4.
```