### PR TITLE
Syntax fix: callable type instead of tuple assignment

### DIFF
--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -93,7 +93,7 @@ end
     sitp(xis...)
 end
 
-(sitp::ScaledInterpolation{T,1}, x::Number, y::Int) where {T} = y == 1 ? sitp(x) : Base.throw_boundserror(sitp, (x, y))
+(sitp::ScaledInterpolation{T,1})(x::Number, y::Int) where {T} = y == 1 ? sitp(x) : Base.throw_boundserror(sitp, (x, y))
 
 @inline function (itp::ScaledInterpolation{T,N})(x::Vararg{Union{Number,AbstractVector},N}) where {T,N}
     [itp(i...) for i in Iterators.product(x...)]


### PR DESCRIPTION
Lowering has a bug where an assignment to a `where`-wrapped tuple is treated like an anonymous function, and it's a very easy typo to make when trying to add a method to a callable type.  I found this syntax in two packages, and both seemed to be typos, so this PR corrects the syntax before I make it a proper error.  Issue reference: https://github.com/JuliaLang/julia/issues/62051