### PR TITLE
Add SciMLBaseExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,12 @@ WoodburyMatrices = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 [weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extensions]
 InterpolationsUnitfulExt = "Unitful"
 InterpolationsForwardDiffExt = "ForwardDiff"
+InterpolationsSciMLBaseExt = "SciMLBase"
 
 [compat]
 Adapt = "2, 3, 4.0"
@@ -31,6 +33,7 @@ ForwardDiff = "0.10, 1.0"
 JLArrays = "0.2"
 OffsetArrays = "0.10, 0.11, 1.0.1"
 Ratios = "0.3, 0.4"
+SciMLBase = "1.9, 2, 3"
 StaticArrays = "0.12, 1"
 Unitful = "1"
 WoodburyMatrices = "0.4, 0.5, 1.0"
@@ -41,9 +44,10 @@ ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ColorVectorSpace", "DualNumbers", "JLArrays", "ForwardDiff", "Test", "Unitful", "Zygote"]
+test = ["ColorVectorSpace", "DualNumbers", "JLArrays", "ForwardDiff", "Test", "SciMLBase", "Unitful", "Zygote"]

--- a/ext/InterpolationsSciMLBaseExt.jl
+++ b/ext/InterpolationsSciMLBaseExt.jl
@@ -1,0 +1,12 @@
+module InterpolationsSciMLBaseExt
+
+using Interpolations: AbstractInterpolation
+using SciMLBase: SciMLBase
+
+# desired behavior is to warn if the contained abstractarray would warn
+# assumes that the interpolation is not empty.
+function SciMLBase.should_warn_paramtype(i::AbstractInterpolation{<:AbstractArray})
+    return SciMLBase.should_warn_paramtype(first(i))
+end
+
+end

--- a/ext/InterpolationsSciMLBaseExt.jl
+++ b/ext/InterpolationsSciMLBaseExt.jl
@@ -1,12 +1,12 @@
 module InterpolationsSciMLBaseExt
 
-using Interpolations: AbstractInterpolation
+using Interpolations: AbstractInterpolation, coefficients
 using SciMLBase: SciMLBase
 
-# desired behavior is to warn if the contained abstractarray would warn
-# assumes that the interpolation is not empty.
-function SciMLBase.should_warn_paramtype(i::AbstractInterpolation{<:AbstractArray})
-    return SciMLBase.should_warn_paramtype(first(i))
+# desired behavior is to warn if the contained array would warn
+# so we just forward the coefficients of the interpolation to the actual warning check
+function SciMLBase.should_warn_paramtype(i::AbstractInterpolation)
+    return SciMLBase.should_warn_paramtype(coefficients(i))
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,7 @@ const isci = get(ENV, "CI", "") in ("true", "True")
     # Chain rules interaction
     include("chainrules.jl")
 
-    #SciMLBase interaction
+    # SciMLBase interaction
     include("scimlbase.jl")
 
     include("gpu_support.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,5 +58,8 @@ const isci = get(ENV, "CI", "") in ("true", "True")
     # Chain rules interaction
     include("chainrules.jl")
 
+    #SciMLBase interaction
+    include("scimlbase.jl")
+
     include("gpu_support.jl")
 end

--- a/test/scimlbase.jl
+++ b/test/scimlbase.jl
@@ -1,0 +1,23 @@
+using SciMLBase, StaticArrays, Interpolations
+
+@testset "SciMLBase should_warn_paramtype" begin
+    # Abstract range
+    Xs_float = 0.0:2.0:10.0
+    Ys_float = Xs_float .^ 2
+    # this might be clunky
+    Ys_number = Vector{Number}(Ys_float)
+    Ys_arr = map(x -> SVector(x^2, 2 * x - 1), Xs_float)
+    Ys_arr_number = map(((i, x),) -> SVector{2, Number}(i, x), enumerate(Xs_float))
+    i_float = interpolate(Ys_float, BSpline(Linear()))
+    i_number = interpolate(Ys_number, BSpline(Linear()))
+    i_arr_float = interpolate(Ys_arr, BSpline(Linear()))
+    i_arr_number = interpolate(Ys_arr_number, NoInterp())
+    # should not warn on concrete number
+    @test SciMLBase.should_warn_paramtype(i_float) == false
+    # should not warn on concrete array eltype
+    @test SciMLBase.should_warn_paramtype(i_arr_float) == false
+    # call operator on abstract number interpolation seems to return f64
+    @test SciMLBase.should_warn_paramtype(i_number) == false
+    # should warn on abstract array eltype
+    @test SciMLBase.should_warn_paramtype(i_arr_number)
+end

--- a/test/scimlbase.jl
+++ b/test/scimlbase.jl
@@ -1,23 +1,36 @@
-using SciMLBase, StaticArrays, Interpolations
+using Interpolations, SciMLBase, StaticArrays
 
 @testset "SciMLBase should_warn_paramtype" begin
-    # Abstract range
-    Xs_float = 0.0:2.0:10.0
-    Ys_float = Xs_float .^ 2
-    # this might be clunky
-    Ys_number = Vector{Number}(Ys_float)
-    Ys_arr = map(x -> SVector(x^2, 2 * x - 1), Xs_float)
-    Ys_arr_number = map(((i, x),) -> SVector{2, Number}(i, x), enumerate(Xs_float))
-    i_float = interpolate(Ys_float, BSpline(Linear()))
-    i_number = interpolate(Ys_number, BSpline(Linear()))
-    i_arr_float = interpolate(Ys_arr, BSpline(Linear()))
-    i_arr_number = interpolate(Ys_arr_number, NoInterp())
+    Xs = 10.0:2.0:20.0
+    # want Y-values that are
+    #   - Concrete
+    Ys_float = Xs .^ 2
+    #   - Abstract
+    Ys_number = Vector{Real}(Ys_float)
+    #   - Array of concrete
+    Ys_arr = map(x -> SVector(x^2, 2 * x - 1), Xs)
+    #   - Array of abstract
+    Ys_arr_number = map(((i, x),) -> SVector{2, Real}(i, x), enumerate(Xs))
+    bspline_concrete_scalar = interpolate(Ys_float, BSpline(Linear()))
+    bspline_abstract_scalar = interpolate(Ys_number, BSpline(Linear()))
+    bspline_concrete_array = interpolate(Ys_arr, BSpline(Linear()))
+    bspline_abstract_array = interpolate(Ys_arr_number, BSpline(Linear()))
+
+    gridded_concrete_scalar = interpolate((Xs,), Ys_float, Gridded(Linear()))
+    gridded_abstract_scalar = interpolate((Xs,), Ys_number, Gridded(Linear()))
+    gridded_concrete_array = interpolate((Xs,), Ys_arr, Gridded(Linear()))
+    gridded_abstract_array = interpolate((Xs,), Ys_arr_number, Gridded(Linear()))
+
     # should not warn on concrete number
-    @test SciMLBase.should_warn_paramtype(i_float) == false
+    @test SciMLBase.should_warn_paramtype(bspline_concrete_scalar) == false
+    @test SciMLBase.should_warn_paramtype(gridded_concrete_scalar) == false
     # should not warn on concrete array eltype
-    @test SciMLBase.should_warn_paramtype(i_arr_float) == false
-    # call operator on abstract number interpolation seems to return f64
-    @test SciMLBase.should_warn_paramtype(i_number) == false
+    @test SciMLBase.should_warn_paramtype(bspline_concrete_array) == false
+    @test SciMLBase.should_warn_paramtype(gridded_concrete_array) == false
+    # should warn on abstract number
+    @test SciMLBase.should_warn_paramtype(bspline_abstract_scalar)
+    @test SciMLBase.should_warn_paramtype(gridded_abstract_scalar)
     # should warn on abstract array eltype
-    @test SciMLBase.should_warn_paramtype(i_arr_number)
+    @test SciMLBase.should_warn_paramtype(bspline_abstract_array)
+    @test SciMLBase.should_warn_paramtype(gridded_abstract_array)
 end


### PR DESCRIPTION
Fixes a possible BoundsError when passing an AbstractInterpolation as a parameter to a SciML problem constructor (DifferentialEquations.jl, NonlinearSolve.jl, Optimization.jl, etc..) where the fact that `AbstractInterpolation{<:AbstractArray} <: AbstractArray{<:AbstractArray}`  would cause the parameter type warning check to iterate over the AbstractInterpolation.

## Changes:
- Adds an extension for SciMLBase
- Adds test for the parameter type warning

## Example Error Details:
<details>

```
ERROR: BoundsError: attempt to access 253-element interpolate((::Vector{Float64},), ::Vector{SVector{2, Float64}}, Gridded(Linear())) with element type SVector{2, Float64} at index [2]
Stacktrace:
  [1] throw_boundserror(A::Interpolations.GriddedInterpolation{SVector{2, Float64}, 1, Vector{SVector{2, Float64}}, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Tuple{Vector{Float64}}}, I::Tuple{Int64})
    @ Base ./essentials.jl:15
  [2] GriddedInterpolation
    @ ~/.julia/packages/Interpolations/rXcvn/src/gridded/indexing.jl:3 [inlined]
  [3] getindex
    @ ~/.julia/packages/Interpolations/rXcvn/src/Interpolations.jl:420 [inlined]
  [4] iterate
    @ ./abstractarray.jl:1235 [inlined]
  [5] _any(f::typeof(SciMLBase.should_warn_paramtype), itr::Interpolations.GriddedInterpolation{SVector{2, Float64}, 1, Vector{SVector{2, Float64}}, Interpolations.Gridded{Interpolations.Linear{Interpolations.Throw{Interpolations.OnGrid}}}, Tuple{Vector{Float64}}}, ::Colon)
    @ Base ./anyall.jl:130
  [6] any
    @ ./reducedim.jl:989 [inlined]
  [7] should_warn_paramtype
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/performance_warnings.jl:5 [inlined]
  [8] _any_tuple
    @ ./anyall.jl:146 [inlined]
  [9] _any_tuple
    @ ./anyall.jl:152 [inlined]
 [10] any
    @ ./anyall.jl:142 [inlined]
 [11] should_warn_paramtype
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/performance_warnings.jl:6 [inlined]
 [12] warn_paramtype (repeats 2 times)
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/performance_warnings.jl:31 [inlined]
 [13] _
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/problems/optimization_problems.jl:121 [inlined]
 [14] OptimizationProblem
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/problems/optimization_problems.jl:110 [inlined]
 [15] #OptimizationProblem#596
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/problems/optimization_problems.jl:137 [inlined]
 [16] OptimizationProblem
    @ ~/.julia/packages/SciMLBase/7YrMQ/src/problems/optimization_problems.jl:133 [inlined]
 [17] w_star(shock::Euler2D.BowShockInterpolation.ShockInterpolation{Float64}, point::SVector{2, Float64})
    @ Euler2D.BowShockInterpolation ~/projects/stce/shockad/Euler2D/src/postprocessing/shock_interpolation.jl:244
 [18] top-level scope
    @ REPL[15]:1
```
</details>